### PR TITLE
Implement Graphiti core poller skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.py[cod]
+.pytest_cache/

--- a/graphiti/__init__.py
+++ b/graphiti/__init__.py
@@ -1,0 +1,6 @@
+"""Graphiti package exposing configuration and state helpers."""
+
+from .config import GraphitiConfig, load_config
+from .state import GraphitiStateStore
+
+__all__ = ["GraphitiConfig", "load_config", "GraphitiStateStore"]

--- a/graphiti/cli.py
+++ b/graphiti/cli.py
@@ -1,0 +1,58 @@
+"""Command line interface for Graphiti."""
+from __future__ import annotations
+
+import argparse
+import json
+from typing import Any
+
+from .config import load_config
+from .state import GraphitiStateStore
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="graphiti")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    sub.add_parser("status", help="Display configuration and state directory information.")
+    return parser
+
+
+def cmd_status(_: argparse.Namespace) -> int:
+    config = load_config()
+    state = GraphitiStateStore()
+    state.ensure_directory()
+
+    payload: dict[str, Any] = {
+        "config": {
+            "neo4j_uri": config.neo4j_uri,
+            "neo4j_user": config.neo4j_user,
+            "group_id": config.group_id,
+            "poll_gmail_drive_calendar_seconds": config.poll_gmail_drive_calendar_seconds,
+            "poll_slack_active_seconds": config.poll_slack_active_seconds,
+            "poll_slack_idle_seconds": config.poll_slack_idle_seconds,
+            "gmail_fallback_days": config.gmail_fallback_days,
+        },
+        "state_directory": str(state.base_dir),
+        "tokens_path_exists": state.tokens_path.exists(),
+        "state_path_exists": state.state_path.exists(),
+    }
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    return 0
+
+
+COMMAND_HANDLERS = {
+    "status": cmd_status,
+}
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    handler = COMMAND_HANDLERS.get(args.command)
+    if handler is None:
+        parser.error(f"Unknown command: {args.command}")
+    return handler(args)
+
+
+if __name__ == "__main__":  # pragma: no cover - entry point
+    raise SystemExit(main())

--- a/graphiti/config.py
+++ b/graphiti/config.py
@@ -1,0 +1,96 @@
+"""Configuration utilities for Graphiti."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Mapping, Optional
+import os
+
+
+DEFAULT_DOTENV_PATH = Path(".env")
+
+
+@dataclass(frozen=True)
+class GraphitiConfig:
+    """Application configuration loaded from environment variables or .env."""
+
+    neo4j_uri: str = "bolt://localhost:7687"
+    neo4j_user: str = "neo4j"
+    neo4j_password: str = "password"
+    group_id: str = "mike_assistant"
+    poll_gmail_drive_calendar_seconds: int = 3600
+    poll_slack_active_seconds: int = 30
+    poll_slack_idle_seconds: int = 3600
+    gmail_fallback_days: int = 7
+
+    @classmethod
+    def from_mapping(
+        cls,
+        values: Mapping[str, str],
+        *,
+        defaults: Optional["GraphitiConfig"] = None,
+    ) -> "GraphitiConfig":
+        """Create a configuration instance from a key/value mapping."""
+
+        defaults = defaults or cls()
+        def get_int(key: str, default: int) -> int:
+            raw = values.get(key)
+            if raw is None or raw.strip() == "":
+                return default
+            try:
+                return int(raw)
+            except ValueError as exc:
+                raise ValueError(f"Invalid integer for {key}: {raw!r}") from exc
+
+        return cls(
+            neo4j_uri=values.get("NEO4J_URI", defaults.neo4j_uri),
+            neo4j_user=values.get("NEO4J_USER", defaults.neo4j_user),
+            neo4j_password=values.get("NEO4J_PASS", defaults.neo4j_password),
+            group_id=values.get("GROUP_ID", defaults.group_id),
+            poll_gmail_drive_calendar_seconds=get_int(
+                "POLL_GMAIL_DRIVE_CAL", defaults.poll_gmail_drive_calendar_seconds
+            ),
+            poll_slack_active_seconds=get_int(
+                "POLL_SLACK_ACTIVE", defaults.poll_slack_active_seconds
+            ),
+            poll_slack_idle_seconds=get_int(
+                "POLL_SLACK_IDLE", defaults.poll_slack_idle_seconds
+            ),
+            gmail_fallback_days=get_int(
+                "GMAIL_FALLBACK_DAYS", defaults.gmail_fallback_days
+            ),
+        )
+
+
+def _parse_dotenv(path: Path) -> Dict[str, str]:
+    """Parse a minimal .env file into a dictionary."""
+
+    data: Dict[str, str] = {}
+    if not path.exists():
+        return data
+
+    for line in path.read_text().splitlines():
+        striped = line.strip()
+        if not striped or striped.startswith("#"):
+            continue
+        if "=" not in striped:
+            continue
+        key, value = striped.split("=", 1)
+        data[key.strip()] = value.strip().strip('"').strip("'")
+    return data
+
+
+def load_config(*, dotenv_path: Optional[Path] = None, environ: Optional[Mapping[str, str]] = None) -> GraphitiConfig:
+    """Load configuration merging `.env` values with environment variables."""
+
+    dotenv_path = dotenv_path or DEFAULT_DOTENV_PATH
+    environ = dict(os.environ if environ is None else environ)
+
+    values: Dict[str, str] = {}
+    values.update(_parse_dotenv(dotenv_path))
+    # Environment variables take precedence over .env
+    values.update(environ)
+    return GraphitiConfig.from_mapping(values)
+
+
+__all__ = ["GraphitiConfig", "load_config"]

--- a/graphiti/episodes.py
+++ b/graphiti/episodes.py
@@ -1,0 +1,124 @@
+"""Episode data model and persistence helpers."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, Dict, Mapping, Optional
+
+
+@dataclass(slots=True)
+class Episode:
+    """Canonical episode representation for Graphiti."""
+
+    group_id: str
+    source: str
+    native_id: str
+    version: str
+    valid_at: datetime
+    invalid_at: Optional[datetime] = None
+    text: Optional[str] = None
+    json: Optional[Mapping[str, Any]] = None
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def episode_id(self) -> str:
+        return f"{self.source}:{self.native_id}:{self.version}"
+
+    def to_properties(self) -> Dict[str, Any]:
+        payload: Dict[str, Any] = {
+            "group_id": self.group_id,
+            "source": self.source,
+            "native_id": self.native_id,
+            "version": self.version,
+            "episode_id": self.episode_id(),
+            "valid_at": self.valid_at.isoformat(),
+            "metadata": dict(self.metadata),
+        }
+        if self.invalid_at:
+            payload["invalid_at"] = self.invalid_at.isoformat()
+        if self.text is not None:
+            payload["text"] = self.text
+        if self.json is not None:
+            payload["json"] = dict(self.json)
+        return payload
+
+
+class Neo4jEpisodeStore:
+    """Persistence layer backed by a Neo4j driver."""
+
+    def __init__(self, driver: Any, *, group_id: str):
+        self._driver = driver
+        self._group_id = group_id
+
+    def upsert_episode(self, episode: Episode) -> None:
+        """Insert a new episode version and invalidate the prior one."""
+
+        if episode.group_id != self._group_id:
+            raise ValueError(
+                f"Episode group_id {episode.group_id!r} does not match store group {self._group_id!r}"
+            )
+
+        with self._driver.session() as session:
+            session.execute_write(self._invalidate_previous_version, episode)
+            session.execute_write(self._write_episode, episode)
+
+    @property
+    def group_id(self) -> str:
+        return self._group_id
+
+    def fetch_latest_episode_by_native_id(self, source: str, native_id: str) -> Optional[Dict[str, Any]]:
+        with self._driver.session() as session:
+            result = session.execute_read(
+                self._fetch_latest, {
+                    "group_id": self._group_id,
+                    "source": source,
+                    "native_id": native_id,
+                }
+            )
+        return result
+
+    @staticmethod
+    def _write_episode(tx, episode: Episode) -> None:  # pragma: no cover - executed via driver mocks
+        properties = episode.to_properties()
+        tx.run(
+            """
+            MERGE (g:Group {group_id: $group_id})
+            MERGE (g)-[:HAS_EPISODE]->(e:Episode {episode_id: $episode_id})
+            SET e = $properties
+            """,
+            group_id=episode.group_id,
+            episode_id=properties["episode_id"],
+            properties=properties,
+        )
+
+    def _invalidate_previous_version(self, tx, episode: Episode) -> None:  # pragma: no cover - executed via driver mocks
+        tx.run(
+            """
+            MATCH (e:Episode {group_id: $group_id, source: $source, native_id: $native_id})
+            WHERE e.episode_id <> $episode_id AND (e.invalid_at IS NULL OR e.invalid_at = "")
+            SET e.invalid_at = $valid_at
+            """,
+            group_id=episode.group_id,
+            source=episode.source,
+            native_id=episode.native_id,
+            episode_id=episode.episode_id(),
+            valid_at=episode.valid_at.isoformat(),
+        )
+
+    @staticmethod
+    def _fetch_latest(tx, params: Mapping[str, Any]) -> Optional[Dict[str, Any]]:  # pragma: no cover - executed via driver mocks
+        record = tx.run(
+            """
+            MATCH (e:Episode {group_id: $group_id, source: $source, native_id: $native_id})
+            RETURN e ORDER BY e.valid_at DESC LIMIT 1
+            """,
+            **params,
+        ).single()
+        if not record:
+            return None
+        node = record[0]
+        if hasattr(node, "_properties"):
+            return dict(node._properties)
+        return dict(node)
+
+
+__all__ = ["Episode", "Neo4jEpisodeStore"]

--- a/graphiti/pollers/__init__.py
+++ b/graphiti/pollers/__init__.py
@@ -1,0 +1,13 @@
+"""Poller implementations for Gmail, Drive, and Calendar."""
+
+from .calendar import CalendarPoller, CalendarSyncTokenExpired
+from .drive import DrivePoller
+from .gmail import GmailPoller, GmailHistoryNotFound
+
+__all__ = [
+    "CalendarPoller",
+    "CalendarSyncTokenExpired",
+    "DrivePoller",
+    "GmailPoller",
+    "GmailHistoryNotFound",
+]

--- a/graphiti/pollers/calendar.py
+++ b/graphiti/pollers/calendar.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Iterable, Mapping, Protocol
+
+from ..config import GraphitiConfig, load_config
+from ..episodes import Episode, Neo4jEpisodeStore
+from ..state import GraphitiStateStore
+
+
+class CalendarSyncTokenExpired(Exception):
+    """Raised when Google Calendar indicates the sync token is invalid."""
+
+
+@dataclass(slots=True)
+class CalendarEventsPage:
+    events: Iterable[Mapping[str, object]]
+    next_sync_token: str
+
+
+class CalendarClient(Protocol):  # pragma: no cover - protocol definition
+    def list_events(self, calendar_id: str, sync_token: str | None) -> CalendarEventsPage: ...
+
+    def full_sync(self, calendar_id: str) -> CalendarEventsPage: ...
+
+
+class CalendarPoller:
+    """Google Calendar incremental poller."""
+
+    def __init__(
+        self,
+        calendar_client: CalendarClient,
+        episode_store: Neo4jEpisodeStore,
+        state_store: GraphitiStateStore,
+        calendar_ids: Iterable[str],
+        config: GraphitiConfig | None = None,
+    ) -> None:
+        self._client = calendar_client
+        self._episodes = episode_store
+        self._state = state_store
+        self._config = config or load_config()
+        if self._episodes.group_id != self._config.group_id:
+            raise ValueError("Episode store group_id does not match configuration group_id")
+        self._group_id = self._config.group_id
+        self._calendar_ids = list(calendar_ids)
+
+    def run_once(self) -> int:
+        state = self._state.load_state()
+        calendar_state = state.get("calendar", {}) if isinstance(state, Mapping) else {}
+        sync_tokens = calendar_state.get("sync_tokens", {}) if isinstance(calendar_state, Mapping) else {}
+
+        processed = 0
+        new_tokens: dict[str, str] = dict(sync_tokens) if isinstance(sync_tokens, Mapping) else {}
+
+        for calendar_id in self._calendar_ids:
+            token = sync_tokens.get(calendar_id) if isinstance(sync_tokens, Mapping) else None
+            try:
+                page = self._client.list_events(calendar_id, token)
+            except CalendarSyncTokenExpired:
+                page = self._client.full_sync(calendar_id)
+
+            for event in page.events:
+                episode = self._normalize_event(calendar_id, event)
+                self._episodes.upsert_episode(episode)
+                processed += 1
+            new_tokens[calendar_id] = page.next_sync_token
+
+        self._state.update_state(
+            {
+                "calendar": {
+                    "sync_tokens": new_tokens,
+                    "last_run_at": datetime.now(timezone.utc).isoformat(),
+                }
+            }
+        )
+        return processed
+
+    def _normalize_event(self, calendar_id: str, event: Mapping[str, object]) -> Episode:
+        event_id = event.get("id")
+        updated = event.get("updated")
+        status = event.get("status")
+        if not isinstance(event_id, str):
+            raise ValueError("Calendar event missing id")
+        if not isinstance(updated, str):
+            raise ValueError(f"Event {event_id} missing updated timestamp")
+
+        valid_at = self._parse_time(updated) or datetime.now(timezone.utc)
+        version = updated
+        metadata = {
+            "calendar_id": calendar_id,
+            "event_id": event_id,
+            "recurringEventId": event.get("recurringEventId"),
+            "tombstone": status == "cancelled",
+        }
+        json_payload = dict(event)
+        if status == "cancelled":
+            json_payload = {"cancelled": True, "event": dict(event)}
+
+        return Episode(
+            group_id=self._group_id,
+            source="calendar",
+            native_id=event_id,
+            version=version,
+            valid_at=valid_at,
+            json=json_payload,
+            metadata=metadata,
+        )
+
+    @staticmethod
+    def _parse_time(value: str) -> datetime | None:
+        try:
+            if value.endswith("Z"):
+                value = value.replace("Z", "+00:00")
+            return datetime.fromisoformat(value).astimezone(timezone.utc)
+        except ValueError:  # pragma: no cover - defensive
+            return None
+
+
+__all__ = [
+    "CalendarPoller",
+    "CalendarClient",
+    "CalendarEventsPage",
+    "CalendarSyncTokenExpired",
+]

--- a/graphiti/pollers/drive.py
+++ b/graphiti/pollers/drive.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Iterable, Mapping, Protocol
+
+from ..config import GraphitiConfig, load_config
+from ..episodes import Episode, Neo4jEpisodeStore
+from ..state import GraphitiStateStore
+
+
+@dataclass(slots=True)
+class DriveChangesResult:
+    changes: Iterable[Mapping[str, object]]
+    new_page_token: str
+
+
+@dataclass(slots=True)
+class DriveFileContent:
+    text: str | None
+    metadata: Mapping[str, object]
+
+
+class DriveClient(Protocol):  # pragma: no cover - protocol definition
+    def list_changes(self, page_token: str | None) -> DriveChangesResult: ...
+
+    def fetch_file_content(self, file_id: str, file_metadata: Mapping[str, object]) -> DriveFileContent: ...
+
+
+class DrivePoller:
+    """Poll Google Drive for changes and emit episodes."""
+
+    def __init__(
+        self,
+        drive_client: DriveClient,
+        episode_store: Neo4jEpisodeStore,
+        state_store: GraphitiStateStore,
+        config: GraphitiConfig | None = None,
+    ) -> None:
+        self._drive = drive_client
+        self._episodes = episode_store
+        self._state = state_store
+        self._config = config or load_config()
+        if self._episodes.group_id != self._config.group_id:
+            raise ValueError("Episode store group_id does not match configuration group_id")
+        self._group_id = self._config.group_id
+
+    def run_once(self) -> int:
+        state = self._state.load_state()
+        drive_state = state.get("drive", {}) if isinstance(state, Mapping) else {}
+        page_token = drive_state.get("page_token") if isinstance(drive_state, Mapping) else None
+
+        result = self._drive.list_changes(page_token)
+        processed = 0
+        for change in result.changes:
+            episode = self._normalize_change(change)
+            if episode is None:
+                continue
+            self._episodes.upsert_episode(episode)
+            processed += 1
+
+        self._state.update_state(
+            {
+                "drive": {
+                    "page_token": result.new_page_token,
+                    "last_run_at": datetime.now(timezone.utc).isoformat(),
+                }
+            }
+        )
+        return processed
+
+    def _normalize_change(self, change: Mapping[str, object]) -> Episode | None:
+        file_id = change.get("fileId")
+        if not isinstance(file_id, str):  # pragma: no cover - defensive
+            return None
+
+        removed = bool(change.get("removed"))
+        file_metadata = change.get("file") if isinstance(change.get("file"), Mapping) else None
+        change_time = change.get("time")
+
+        if removed or (isinstance(file_metadata, Mapping) and file_metadata.get("trashed")):
+            timestamp = self._parse_time(change_time) or datetime.now(timezone.utc)
+            version = f"deleted:{timestamp.isoformat()}"
+            metadata = {
+                "file_id": file_id,
+                "tombstone": True,
+            }
+            return Episode(
+                group_id=self._group_id,
+                source="gdrive",
+                native_id=file_id,
+                version=version,
+                valid_at=timestamp,
+                json={"deleted": True},
+                metadata=metadata,
+            )
+
+        if not isinstance(file_metadata, Mapping):
+            return None
+
+        modified_time = file_metadata.get("modifiedTime")
+        valid_at = self._parse_time(modified_time) or self._parse_time(change_time)
+        if valid_at is None:
+            valid_at = datetime.now(timezone.utc)
+        version = str(file_metadata.get("headRevisionId") or file_metadata.get("modifiedTime") or valid_at.isoformat())
+
+        content = self._drive.fetch_file_content(file_id, file_metadata)
+        text = content.text
+        metadata = {
+            "file_id": file_id,
+            "name": file_metadata.get("name"),
+            "mimeType": file_metadata.get("mimeType"),
+            "webViewLink": file_metadata.get("webViewLink"),
+        }
+        metadata.update({k: v for k, v in content.metadata.items()})
+
+        return Episode(
+            group_id=self._group_id,
+            source="gdrive",
+            native_id=file_id,
+            version=version,
+            valid_at=valid_at,
+            text=text,
+            metadata=metadata,
+        )
+
+    @staticmethod
+    def _parse_time(value: object) -> datetime | None:
+        if not isinstance(value, str):
+            return None
+        try:
+            if value.endswith("Z"):
+                value = value.replace("Z", "+00:00")
+            return datetime.fromisoformat(value).astimezone(timezone.utc)
+        except ValueError:  # pragma: no cover - defensive
+            return None
+
+
+__all__ = ["DrivePoller", "DriveClient", "DriveChangesResult", "DriveFileContent"]

--- a/graphiti/pollers/gmail.py
+++ b/graphiti/pollers/gmail.py
@@ -1,0 +1,132 @@
+"""Gmail poller implementation."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Iterable, Mapping, Protocol
+
+from ..config import GraphitiConfig, load_config
+from ..episodes import Episode, Neo4jEpisodeStore
+from ..state import GraphitiStateStore
+
+
+class GmailHistoryNotFound(Exception):
+    """Raised when the Gmail history API indicates the history ID is invalid."""
+
+
+@dataclass(slots=True)
+class GmailHistoryResult:
+    message_ids: list[str]
+    latest_history_id: str
+
+
+class GmailClient(Protocol):  # pragma: no cover - protocol definition
+    def list_history(self, start_history_id: str | None) -> GmailHistoryResult: ...
+
+    def fallback_fetch(self, newer_than_days: int) -> GmailHistoryResult: ...
+
+    def fetch_message(self, message_id: str) -> Mapping[str, object]: ...
+
+
+class GmailPoller:
+    """Incremental Gmail poller with fallback behavior."""
+
+    def __init__(
+        self,
+        gmail_client: GmailClient,
+        episode_store: Neo4jEpisodeStore,
+        state_store: GraphitiStateStore,
+        config: GraphitiConfig | None = None,
+    ) -> None:
+        self._gmail = gmail_client
+        self._episodes = episode_store
+        self._state = state_store
+        self._config = config or load_config()
+        if self._episodes.group_id != self._config.group_id:
+            raise ValueError(
+                "Episode store group_id does not match configuration group_id"
+            )
+        self._group_id = self._config.group_id
+
+    def run_once(self) -> int:
+        state = self._state.load_state()
+        gmail_state = state.get("gmail", {}) if isinstance(state, Mapping) else {}
+        last_history_id = gmail_state.get("last_history_id") if isinstance(gmail_state, Mapping) else None
+
+        try:
+            history = self._gmail.list_history(last_history_id)
+            fallback_used = False
+        except GmailHistoryNotFound:
+            history = self._gmail.fallback_fetch(self._config.gmail_fallback_days)
+            fallback_used = True
+
+        processed = 0
+        seen: set[str] = set()
+        for message_id in history.message_ids:
+            if message_id in seen:
+                continue
+            seen.add(message_id)
+            message = self._gmail.fetch_message(message_id)
+            episode = self._normalize_message(message)
+            self._episodes.upsert_episode(episode)
+            processed += 1
+
+        update_payload = {
+            "gmail": {
+                "last_history_id": history.latest_history_id,
+                "last_run_at": datetime.now(timezone.utc).isoformat(),
+                "fallback_used": fallback_used,
+            }
+        }
+        self._state.update_state(update_payload)
+        return processed
+
+    def _normalize_message(self, message: Mapping[str, object]) -> Episode:
+        message_id = str(message.get("id"))
+        if not message_id:
+            raise ValueError("Gmail message missing id")
+        native_id = message_id
+        thread_id = message.get("threadId")
+        internal_date_raw = message.get("internalDate")
+        if internal_date_raw is None:
+            raise ValueError(f"Message {message_id} missing internalDate")
+        try:
+            internal_ms = int(internal_date_raw)
+        except (TypeError, ValueError) as exc:  # pragma: no cover - defensive
+            raise ValueError(
+                f"Message {message_id} has invalid internalDate {internal_date_raw!r}"
+            ) from exc
+        internal_date = datetime.fromtimestamp(internal_ms / 1000, tz=timezone.utc)
+        history_id = str(message.get("historyId") or internal_ms)
+        snippet = message.get("snippet")
+
+        headers = {}
+        payload = message.get("payload")
+        if isinstance(payload, Mapping):
+            headers_list = payload.get("headers")
+            if isinstance(headers_list, Iterable):
+                for header in headers_list:
+                    if isinstance(header, Mapping):
+                        name = header.get("name")
+                        value = header.get("value")
+                        if isinstance(name, str) and isinstance(value, str):
+                            headers[name.lower()] = value
+
+        metadata = {
+            "message_id": message_id,
+            "thread_id": thread_id,
+            "headers": headers,
+        }
+
+        return Episode(
+            group_id=self._group_id,
+            source="gmail",
+            native_id=native_id,
+            version=history_id,
+            valid_at=internal_date,
+            text=str(snippet) if snippet is not None else None,
+            metadata=metadata,
+        )
+
+
+__all__ = ["GmailPoller", "GmailHistoryNotFound", "GmailHistoryResult"]

--- a/graphiti/state.py
+++ b/graphiti/state.py
@@ -1,0 +1,89 @@
+"""Local state directory manager."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, Mapping, MutableMapping
+import json
+import os
+
+STATE_DIR_NAME = ".graphiti_sync"
+TOKENS_FILE = "tokens.json"
+STATE_FILE = "state.json"
+
+
+def _ensure_mode(path: Path, mode: int) -> None:
+    """Ensure the file at *path* has the provided permission bits."""
+
+    if path.exists():
+        os.chmod(path, mode)
+
+
+@dataclass
+class GraphitiStateStore:
+    """Manage the on-disk state required for pollers and auth tokens."""
+
+    base_dir: Path = field(default_factory=lambda: Path.home() / STATE_DIR_NAME)
+
+    def __post_init__(self) -> None:
+        self.ensure_directory()
+
+    def ensure_directory(self) -> Path:
+        """Ensure the state directory exists with the proper permissions."""
+
+        self.base_dir.mkdir(parents=True, exist_ok=True)
+        os.chmod(self.base_dir, 0o700)
+        return self.base_dir
+
+    # ---- tokens management ----
+    @property
+    def tokens_path(self) -> Path:
+        return self.base_dir / TOKENS_FILE
+
+    @property
+    def state_path(self) -> Path:
+        return self.base_dir / STATE_FILE
+
+    def load_tokens(self) -> Dict[str, Any]:
+        if not self.tokens_path.exists():
+            return {}
+        with self.tokens_path.open("r", encoding="utf-8") as fh:
+            return json.load(fh)
+
+    def save_tokens(self, tokens: Mapping[str, Any]) -> None:
+        self._write_json(self.tokens_path, tokens)
+
+    def load_state(self) -> Dict[str, Any]:
+        if not self.state_path.exists():
+            return {}
+        with self.state_path.open("r", encoding="utf-8") as fh:
+            return json.load(fh)
+
+    def save_state(self, state: Mapping[str, Any]) -> None:
+        self._write_json(self.state_path, state)
+
+    def update_state(self, update: Mapping[str, Any]) -> Dict[str, Any]:
+        current = self.load_state()
+        merged = _deep_merge(current, update)
+        self.save_state(merged)
+        return merged
+
+    def _write_json(self, path: Path, data: Mapping[str, Any]) -> None:
+        tmp_path = path.with_suffix(".tmp")
+        with tmp_path.open("w", encoding="utf-8") as fh:
+            json.dump(data, fh, indent=2, sort_keys=True)
+            fh.write("\n")
+        os.replace(tmp_path, path)
+        _ensure_mode(path, 0o600)
+
+
+def _deep_merge(base: MutableMapping[str, Any], update: Mapping[str, Any]) -> MutableMapping[str, Any]:
+    for key, value in update.items():
+        if isinstance(value, Mapping) and isinstance(base.get(key), Mapping):
+            base[key] = _deep_merge(dict(base[key]), value)  # type: ignore[index]
+        else:
+            base[key] = value  # type: ignore[index]
+    return base
+
+
+__all__ = ["GraphitiStateStore"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_calendar_poller.py
+++ b/tests/test_calendar_poller.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from unittest import mock
+
+import pytest
+
+from graphiti.config import GraphitiConfig
+from graphiti.episodes import Neo4jEpisodeStore
+from graphiti.pollers.calendar import (
+    CalendarEventsPage,
+    CalendarPoller,
+    CalendarSyncTokenExpired,
+)
+from graphiti.state import GraphitiStateStore
+
+
+def _event(event_id: str, *, status: str = "confirmed") -> dict[str, object]:
+    return {
+        "id": event_id,
+        "updated": "2024-01-01T00:00:00Z",
+        "status": status,
+        "summary": "Meeting",
+    }
+
+
+def test_calendar_poller_updates_tokens(tmp_path):
+    config = GraphitiConfig(group_id="group")
+    client = mock.MagicMock()
+    client.list_events.return_value = CalendarEventsPage([_event("e1"), _event("e2")], "sync-2")
+
+    episode_store = mock.MagicMock(spec=Neo4jEpisodeStore)
+    type(episode_store).group_id = mock.PropertyMock(return_value=config.group_id)
+    state_store = GraphitiStateStore(base_dir=tmp_path / "state")
+    state_store.save_state({"calendar": {"sync_tokens": {"primary": "sync-1"}}})
+
+    poller = CalendarPoller(client, episode_store, state_store, ["primary"], config)
+    processed = poller.run_once()
+
+    assert processed == 2
+    client.list_events.assert_called_once_with("primary", "sync-1")
+    state = state_store.load_state()["calendar"]
+    assert state["sync_tokens"]["primary"] == "sync-2"
+
+
+def test_calendar_poller_handles_cancelled_event(tmp_path):
+    config = GraphitiConfig(group_id="group")
+    client = mock.MagicMock()
+    client.list_events.return_value = CalendarEventsPage([_event("e1", status="cancelled")], "sync-2")
+
+    episode_store = mock.MagicMock(spec=Neo4jEpisodeStore)
+    type(episode_store).group_id = mock.PropertyMock(return_value=config.group_id)
+    state_store = GraphitiStateStore(base_dir=tmp_path / "state")
+
+    poller = CalendarPoller(client, episode_store, state_store, ["primary"], config)
+    poller.run_once()
+
+    episode = episode_store.upsert_episode.call_args.args[0]
+    assert episode.metadata["tombstone"] is True
+    assert episode.json["cancelled"] is True
+
+
+def test_calendar_poller_performs_full_sync_on_token_expiry(tmp_path):
+    config = GraphitiConfig(group_id="group")
+    client = mock.MagicMock()
+    client.list_events.side_effect = CalendarSyncTokenExpired()
+    client.full_sync.return_value = CalendarEventsPage([_event("e1")], "sync-3")
+
+    episode_store = mock.MagicMock(spec=Neo4jEpisodeStore)
+    type(episode_store).group_id = mock.PropertyMock(return_value=config.group_id)
+    state_store = GraphitiStateStore(base_dir=tmp_path / "state")
+
+    poller = CalendarPoller(client, episode_store, state_store, ["primary"], config)
+    processed = poller.run_once()
+
+    assert processed == 1
+    client.full_sync.assert_called_once_with("primary")
+
+
+def test_calendar_poller_validates_group(tmp_path):
+    config = GraphitiConfig(group_id="expected")
+    episode_store = mock.MagicMock(spec=Neo4jEpisodeStore)
+    type(episode_store).group_id = mock.PropertyMock(return_value="other")
+    state_store = GraphitiStateStore(base_dir=tmp_path / "state")
+
+    with pytest.raises(ValueError):
+        CalendarPoller(mock.MagicMock(), episode_store, state_store, ["primary"], config)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import json
+import pathlib
+from unittest import mock
+
+from graphiti import GraphitiStateStore, cli
+
+
+def test_cli_status_outputs_json(monkeypatch, tmp_path, capsys):
+    monkeypatch.setattr(pathlib.Path, "home", lambda: tmp_path)
+    state_store = GraphitiStateStore()
+    monkeypatch.setattr(cli, "GraphitiStateStore", lambda: state_store)
+    monkeypatch.setattr(cli, "load_config", mock.Mock(return_value=mock.Mock(
+        neo4j_uri="bolt://localhost:7687",
+        neo4j_user="neo4j",
+        group_id="group",
+        poll_gmail_drive_calendar_seconds=3600,
+        poll_slack_active_seconds=30,
+        poll_slack_idle_seconds=3600,
+        gmail_fallback_days=7,
+    )))
+
+    exit_code = cli.main(["status"])
+    assert exit_code == 0
+    data = json.loads(capsys.readouterr().out)
+    assert data["state_directory"] == str(state_store.base_dir)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,31 @@
+import os
+from pathlib import Path
+
+import pytest
+
+from graphiti.config import GraphitiConfig, load_config
+
+
+def test_load_config_prefers_environment(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    dotenv = tmp_path / ".env"
+    dotenv.write_text("NEO4J_URI=bolt://dotenv:7687\nPOLL_GMAIL_DRIVE_CAL=100\n")
+
+    monkeypatch.setenv("NEO4J_URI", "bolt://env:7687")
+    monkeypatch.setenv("POLL_GMAIL_DRIVE_CAL", "200")
+
+    config = load_config(dotenv_path=dotenv, environ=os.environ)
+    assert config.neo4j_uri == "bolt://env:7687"
+    assert config.poll_gmail_drive_calendar_seconds == 200
+
+
+def test_invalid_integer_raises(tmp_path: Path) -> None:
+    dotenv = tmp_path / ".env"
+    dotenv.write_text("POLL_SLACK_ACTIVE=not-an-int\n")
+    with pytest.raises(ValueError):
+        load_config(dotenv_path=dotenv, environ={})
+
+
+def test_defaults_when_missing(tmp_path: Path) -> None:
+    config = load_config(dotenv_path=tmp_path / ".env", environ={})
+    assert isinstance(config, GraphitiConfig)
+    assert config.group_id == "mike_assistant"

--- a/tests/test_drive_poller.py
+++ b/tests/test_drive_poller.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from unittest import mock
+
+import pytest
+
+from graphiti.config import GraphitiConfig
+from graphiti.episodes import Neo4jEpisodeStore
+from graphiti.pollers.drive import (
+    DriveChangesResult,
+    DriveFileContent,
+    DrivePoller,
+)
+from graphiti.state import GraphitiStateStore
+
+
+def _change(file_id: str, *, removed: bool = False) -> dict[str, object]:
+    return {
+        "fileId": file_id,
+        "removed": removed,
+        "time": "2024-01-01T00:00:00Z",
+        "file": None if removed else {
+            "modifiedTime": "2024-01-01T00:00:00Z",
+            "headRevisionId": "rev-1",
+            "name": "Doc",
+            "mimeType": "application/vnd.google-apps.document",
+            "webViewLink": "http://example.com",
+        },
+    }
+
+
+def test_drive_poller_processes_changes(tmp_path):
+    config = GraphitiConfig(group_id="test_group")
+    drive_client = mock.MagicMock()
+    drive_client.list_changes.return_value = DriveChangesResult([_change("f1")], "token-2")
+    drive_client.fetch_file_content.return_value = DriveFileContent("text", {"owners": ["alice"]})
+
+    episode_store = mock.MagicMock(spec=Neo4jEpisodeStore)
+    type(episode_store).group_id = mock.PropertyMock(return_value=config.group_id)
+    state_store = GraphitiStateStore(base_dir=tmp_path / "state")
+    state_store.save_state({"drive": {"page_token": "token-1"}})
+
+    poller = DrivePoller(drive_client, episode_store, state_store, config)
+    processed = poller.run_once()
+
+    assert processed == 1
+    drive_client.list_changes.assert_called_once_with("token-1")
+    episode_store.upsert_episode.assert_called_once()
+    saved = state_store.load_state()["drive"]
+    assert saved["page_token"] == "token-2"
+
+
+def test_drive_poller_creates_tombstone_for_removals(tmp_path):
+    config = GraphitiConfig(group_id="test_group")
+    drive_client = mock.MagicMock()
+    drive_client.list_changes.return_value = DriveChangesResult([_change("f1", removed=True)], "token-3")
+
+    episode_store = mock.MagicMock(spec=Neo4jEpisodeStore)
+    type(episode_store).group_id = mock.PropertyMock(return_value=config.group_id)
+    state_store = GraphitiStateStore(base_dir=tmp_path / "state")
+
+    poller = DrivePoller(drive_client, episode_store, state_store, config)
+    processed = poller.run_once()
+
+    assert processed == 1
+    drive_client.fetch_file_content.assert_not_called()
+    episode = episode_store.upsert_episode.call_args.args[0]
+    assert episode.json == {"deleted": True}
+    assert episode.metadata["tombstone"] is True
+
+
+def test_drive_poller_validates_group(tmp_path):
+    config = GraphitiConfig(group_id="expected")
+    episode_store = mock.MagicMock(spec=Neo4jEpisodeStore)
+    type(episode_store).group_id = mock.PropertyMock(return_value="other")
+    state_store = GraphitiStateStore(base_dir=tmp_path / "state")
+
+    with pytest.raises(ValueError):
+        DrivePoller(mock.MagicMock(), episode_store, state_store, config)

--- a/tests/test_episodes.py
+++ b/tests/test_episodes.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest import mock
+
+import pytest
+
+from graphiti.episodes import Episode, Neo4jEpisodeStore
+
+
+def test_episode_properties_include_optional_fields() -> None:
+    episode = Episode(
+        group_id="mike_assistant",
+        source="gmail",
+        native_id="mid",
+        version="123",
+        valid_at=datetime(2024, 1, 1, tzinfo=timezone.utc),
+        invalid_at=datetime(2024, 1, 2, tzinfo=timezone.utc),
+        text="hello",
+        json={"key": "value"},
+        metadata={"message_id": "mid"},
+    )
+    props = episode.to_properties()
+    assert props["invalid_at"] == "2024-01-02T00:00:00+00:00"
+    assert props["text"] == "hello"
+    assert props["json"] == {"key": "value"}
+
+
+def test_upsert_episode_executes_queries_in_order() -> None:
+    driver = mock.MagicMock()
+    session = driver.session.return_value.__enter__.return_value
+
+    episode = Episode(
+        group_id="mike_assistant",
+        source="gmail",
+        native_id="mid",
+        version="123",
+        valid_at=datetime(2024, 1, 1, tzinfo=timezone.utc),
+    )
+
+    store = Neo4jEpisodeStore(driver, group_id="mike_assistant")
+    store.upsert_episode(episode)
+
+    session.execute_write.assert_any_call(store._invalidate_previous_version, episode)
+    session.execute_write.assert_any_call(store._write_episode, episode)
+
+
+def test_upsert_episode_rejects_mismatched_group() -> None:
+    driver = mock.MagicMock()
+    store = Neo4jEpisodeStore(driver, group_id="expected")
+    episode = Episode(
+        group_id="other",
+        source="gmail",
+        native_id="mid",
+        version="123",
+        valid_at=datetime(2024, 1, 1, tzinfo=timezone.utc),
+    )
+
+    with pytest.raises(ValueError):
+        store.upsert_episode(episode)
+
+
+def test_fetch_latest_episode_calls_driver() -> None:
+    driver = mock.MagicMock()
+    session = driver.session.return_value.__enter__.return_value
+    session.execute_read.return_value = {"episode_id": "gmail:mid:123"}
+
+    store = Neo4jEpisodeStore(driver, group_id="mike_assistant")
+    result = store.fetch_latest_episode_by_native_id("gmail", "mid")
+
+    assert result == {"episode_id": "gmail:mid:123"}
+    session.execute_read.assert_called_once()

--- a/tests/test_gmail_poller.py
+++ b/tests/test_gmail_poller.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest import mock
+
+import pytest
+
+from graphiti.config import GraphitiConfig
+from graphiti.episodes import Neo4jEpisodeStore
+from graphiti.pollers.gmail import (
+    GmailHistoryNotFound,
+    GmailHistoryResult,
+    GmailPoller,
+)
+from graphiti.state import GraphitiStateStore
+
+
+def _message(message_id: str, *, history_id: str = "2", snippet: str = "hello") -> dict[str, object]:
+    return {
+        "id": message_id,
+        "threadId": "thread-1",
+        "historyId": history_id,
+        "internalDate": "1700000000000",
+        "snippet": snippet,
+        "payload": {
+            "headers": [
+                {"name": "From", "value": "alice@example.com"},
+                {"name": "To", "value": "bob@example.com"},
+            ]
+        },
+    }
+
+
+def test_gmail_poller_incremental_updates_state(tmp_path):
+    config = GraphitiConfig(group_id="test_group")
+    gmail_client = mock.MagicMock()
+    gmail_client.list_history.return_value = GmailHistoryResult(["m1", "m1"], "456")
+    gmail_client.fetch_message.return_value = _message("m1")
+
+    episode_store = mock.MagicMock(spec=Neo4jEpisodeStore)
+    type(episode_store).group_id = mock.PropertyMock(return_value=config.group_id)
+    state_store = GraphitiStateStore(base_dir=tmp_path / "state")
+    state_store.save_state({"gmail": {"last_history_id": "123"}})
+
+    poller = GmailPoller(gmail_client, episode_store, state_store, config)
+    processed = poller.run_once()
+
+    assert processed == 1
+    gmail_client.list_history.assert_called_once_with("123")
+    episode_store.upsert_episode.assert_called_once()
+    saved = state_store.load_state()["gmail"]
+    assert saved["last_history_id"] == "456"
+    assert saved["fallback_used"] is False
+
+
+def test_gmail_poller_uses_fallback_on_missing_history(tmp_path):
+    config = GraphitiConfig(group_id="test_group", gmail_fallback_days=9)
+    gmail_client = mock.MagicMock()
+    gmail_client.list_history.side_effect = GmailHistoryNotFound()
+    gmail_client.fallback_fetch.return_value = GmailHistoryResult(["m1"], "900")
+    gmail_client.fetch_message.return_value = _message("m1")
+
+    episode_store = mock.MagicMock(spec=Neo4jEpisodeStore)
+    type(episode_store).group_id = mock.PropertyMock(return_value=config.group_id)
+    state_store = GraphitiStateStore(base_dir=tmp_path / "state")
+
+    poller = GmailPoller(gmail_client, episode_store, state_store, config)
+    processed = poller.run_once()
+
+    assert processed == 1
+    gmail_client.fallback_fetch.assert_called_once_with(9)
+    saved = state_store.load_state()["gmail"]
+    assert saved["fallback_used"] is True
+
+
+def test_gmail_poller_validates_group_id(tmp_path):
+    config = GraphitiConfig(group_id="expected")
+    episode_store = mock.MagicMock(spec=Neo4jEpisodeStore)
+    type(episode_store).group_id = mock.PropertyMock(return_value="other")
+    state_store = GraphitiStateStore(base_dir=tmp_path / "state")
+
+    with pytest.raises(ValueError):
+        GmailPoller(mock.MagicMock(), episode_store, state_store, config)

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from graphiti.state import GraphitiStateStore
+
+
+def test_state_directory_created_with_permissions(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+    store = GraphitiStateStore()
+    path = store.ensure_directory()
+    assert path.exists()
+    assert path.stat().st_mode & 0o777 == 0o700
+
+
+def test_update_state_merges_nested(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+    store = GraphitiStateStore()
+    store.save_state({"gmail": {"last_history_id": "1"}, "drive": {"page_token": "abc"}})
+
+    updated = store.update_state({"gmail": {"last_history_id": "2"}, "calendar": {"sync_tokens": {"id": "tok"}}})
+    assert updated["gmail"]["last_history_id"] == "2"
+    assert updated["drive"]["page_token"] == "abc"
+    assert updated["calendar"]["sync_tokens"]["id"] == "tok"


### PR DESCRIPTION
## Summary
- add the initial `graphiti` package with configuration loader, CLI status command, and state directory manager
- implement the episode data model with a Neo4j persistence facade and add Gmail, Drive, and Calendar pollers including fallback logic
- create pytest coverage for configuration, state, CLI, persistence, and poller behaviors

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dc6c5e6d3883308bee888f595809ec