### PR TITLE
Add CLI sync commands, Slack poller, and query tooling

### DIFF
--- a/graphiti/cli.py
+++ b/graphiti/cli.py
@@ -3,25 +3,78 @@ from __future__ import annotations
 
 import argparse
 import json
-from typing import Any
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Callable, Iterable, Mapping
 
-from .config import load_config
+from .config import GraphitiConfig, load_config
+from .episodes import Neo4jEpisodeStore
+from .pollers.calendar import CalendarPoller
+from .pollers.drive import DrivePoller
+from .pollers.gmail import GmailPoller
+from .pollers.slack import SlackPoller
 from .state import GraphitiStateStore
+
+DEFAULT_INDENT = 2
 
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="graphiti")
     sub = parser.add_subparsers(dest="command", required=True)
 
-    sub.add_parser("status", help="Display configuration and state directory information.")
+    status_parser = sub.add_parser(
+        "status", help="Display configuration and state directory information."
+    )
+    status_parser.set_defaults(func=cmd_status)
+
+    sync = sub.add_parser("sync", help="Synchronisation utilities")
+    sync_sub = sync.add_subparsers(dest="sync_command", required=True)
+
+    for source in ("gmail", "drive", "calendar"):
+        poller_parser = sync_sub.add_parser(source, help=f"Run the {source} poller once")
+        poller_parser.add_argument(
+            "--once",
+            action="store_true",
+            required=True,
+            help="Execute a single polling iteration",
+        )
+        poller_parser.set_defaults(func=cmd_sync_poller, poller_name=source)
+
+    slack_parser = sync_sub.add_parser("slack", help="Slack poller utilities")
+    group = slack_parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--once", action="store_true", help="Run the Slack poller once")
+    group.add_argument(
+        "--list-channels",
+        action="store_true",
+        help="List discoverable Slack channels and persist metadata",
+    )
+    slack_parser.set_defaults(func=cmd_sync_slack)
+
+    sync_status = sync_sub.add_parser(
+        "status", help="Summarise the last recorded sync checkpoints"
+    )
+    sync_status.set_defaults(func=cmd_sync_status)
+
+    scheduler = sync_sub.add_parser("scheduler", help="Run the scheduler stub")
+    scheduler.add_argument(
+        "--once",
+        action="store_true",
+        help="Execute each poller sequentially once",
+    )
+    scheduler.set_defaults(func=cmd_sync_scheduler)
+
     return parser
 
 
-def cmd_status(_: argparse.Namespace) -> int:
+def _bootstrap() -> tuple[GraphitiConfig, GraphitiStateStore]:
     config = load_config()
     state = GraphitiStateStore()
     state.ensure_directory()
+    return config, state
 
+
+def cmd_status(_: argparse.Namespace) -> int:
+    config, state = _bootstrap()
     payload: dict[str, Any] = {
         "config": {
             "neo4j_uri": config.neo4j_uri,
@@ -31,17 +84,296 @@ def cmd_status(_: argparse.Namespace) -> int:
             "poll_slack_active_seconds": config.poll_slack_active_seconds,
             "poll_slack_idle_seconds": config.poll_slack_idle_seconds,
             "gmail_fallback_days": config.gmail_fallback_days,
+            "calendar_ids": list(config.calendar_ids),
+            "slack_channel_allowlist": list(config.slack_channel_allowlist),
         },
         "state_directory": str(state.base_dir),
         "tokens_path_exists": state.tokens_path.exists(),
         "state_path_exists": state.state_path.exists(),
     }
-    print(json.dumps(payload, indent=2, sort_keys=True))
+    print(json.dumps(payload, indent=DEFAULT_INDENT, sort_keys=True))
     return 0
+
+
+def cmd_sync_status(_: argparse.Namespace) -> int:
+    config, state = _bootstrap()
+    data = state.load_state()
+
+    def _extract(source: str) -> Mapping[str, Any]:
+        value = data.get(source)
+        return value if isinstance(value, Mapping) else {}
+
+    summary = {
+        source: {
+            "last_run_at": _extract(source).get("last_run_at"),
+            "checkpoint": {
+                key: value
+                for key, value in _extract(source).items()
+                if key not in {"last_run_at"}
+            },
+        }
+        for source in ("gmail", "drive", "calendar", "slack")
+    }
+    summary["config"] = {
+        "group_id": config.group_id,
+        "calendar_ids": list(config.calendar_ids),
+        "slack_allowlist": list(config.slack_channel_allowlist),
+    }
+    print(json.dumps(summary, indent=DEFAULT_INDENT, sort_keys=True))
+    return 0
+
+
+def cmd_sync_poller(args: argparse.Namespace) -> int:
+    config, state = _bootstrap()
+    episode_store = create_episode_store(config)
+    poller_factory = POLLER_FACTORIES[args.poller_name]
+    try:
+        poller = poller_factory(config, state, episode_store)
+        processed = poller.run_once()
+    finally:
+        close_episode_store(episode_store)
+
+    payload = {
+        "source": args.poller_name,
+        "processed": processed,
+        "ran_at": datetime.now(timezone.utc).isoformat(),
+    }
+    print(json.dumps(payload, indent=DEFAULT_INDENT, sort_keys=True))
+    return 0
+
+
+def cmd_sync_slack(args: argparse.Namespace) -> int:
+    config, state = _bootstrap()
+    episode_store = create_episode_store(config)
+    client = create_slack_client(config, state)
+
+    try:
+        if getattr(args, "list_channels", False):
+            channels = list(client.list_channels())
+            filtered = _filter_channels(channels, config.slack_channel_allowlist)
+            state.update_state(
+                {
+                    "slack": {
+                        "channels": {
+                            str(c.get("id")): dict(c)
+                            for c in filtered
+                            if isinstance(c, Mapping) and c.get("id")
+                        },
+                        "last_inventory_at": datetime.now(timezone.utc).isoformat(),
+                    }
+                }
+            )
+            print(json.dumps(filtered, indent=DEFAULT_INDENT, sort_keys=True))
+            return 0
+
+        poller = SlackPoller(
+            client,
+            episode_store,
+            state,
+            allowlist=config.slack_channel_allowlist,
+        )
+        processed = poller.run_once()
+        payload = {
+            "source": "slack",
+            "processed": processed,
+            "ran_at": datetime.now(timezone.utc).isoformat(),
+        }
+        print(json.dumps(payload, indent=DEFAULT_INDENT, sort_keys=True))
+        return 0
+    finally:
+        close_episode_store(episode_store)
+
+
+def cmd_sync_scheduler(args: argparse.Namespace) -> int:
+    config, state = _bootstrap()
+    if not getattr(args, "once", False):
+        payload = {
+            "poll_gmail_drive_calendar_seconds": config.poll_gmail_drive_calendar_seconds,
+            "poll_slack_active_seconds": config.poll_slack_active_seconds,
+            "poll_slack_idle_seconds": config.poll_slack_idle_seconds,
+        }
+        print(json.dumps(payload, indent=DEFAULT_INDENT, sort_keys=True))
+        return 0
+
+    metrics: list[dict[str, Any]] = []
+    episode_store = create_episode_store(config)
+    try:
+        for name in ("gmail", "drive", "calendar"):
+            poller = POLLER_FACTORIES[name](config, state, episode_store)
+            metrics.append(
+                {
+                    "source": name,
+                    "processed": poller.run_once(),
+                }
+            )
+        slack_client = create_slack_client(config, state)
+        slack_poller = SlackPoller(
+            slack_client,
+            episode_store,
+            state,
+            allowlist=config.slack_channel_allowlist,
+        )
+        metrics.append({"source": "slack", "processed": slack_poller.run_once()})
+    finally:
+        close_episode_store(episode_store)
+
+    payload = {
+        "ran_at": datetime.now(timezone.utc).isoformat(),
+        "metrics": metrics,
+    }
+    print(json.dumps(payload, indent=DEFAULT_INDENT, sort_keys=True))
+    return 0
+
+
+def _filter_channels(
+    channels: Iterable[Mapping[str, Any]],
+    allowlist: Iterable[str] | None,
+) -> list[Mapping[str, Any]]:
+    allow = {channel.lower() for channel in allowlist or ()}
+    if not allow:
+        return [dict(channel) for channel in channels]
+    filtered: list[Mapping[str, Any]] = []
+    for channel in channels:
+        channel_id = str(channel.get("id", "")).lower()
+        name = str(channel.get("name", "")).lower()
+        if channel_id in allow or name in allow:
+            filtered.append(dict(channel))
+    return filtered
+
+
+def create_episode_store(config: GraphitiConfig) -> Neo4jEpisodeStore:
+    driver = create_neo4j_driver(config)
+    return Neo4jEpisodeStore(driver, group_id=config.group_id)
+
+
+def create_neo4j_driver(config: GraphitiConfig):  # pragma: no cover - requires neo4j driver
+    try:
+        from neo4j import GraphDatabase  # type: ignore
+    except ImportError as exc:  # pragma: no cover - executed when driver missing
+        raise RuntimeError(
+            "The neo4j Python driver is required to use the CLI sync commands"
+        ) from exc
+    return GraphDatabase.driver(
+        config.neo4j_uri,
+        auth=(config.neo4j_user, config.neo4j_password),
+    )
+
+
+def close_episode_store(store: Neo4jEpisodeStore) -> None:
+    driver = getattr(store, "_driver", None)
+    if driver and hasattr(driver, "close"):
+        driver.close()
+
+
+def create_gmail_poller(
+    config: GraphitiConfig,
+    state: GraphitiStateStore,
+    episode_store: Neo4jEpisodeStore,
+) -> GmailPoller:
+    client = create_gmail_client(config, state)
+    return GmailPoller(client, episode_store, state, config)
+
+
+def create_drive_poller(
+    config: GraphitiConfig,
+    state: GraphitiStateStore,
+    episode_store: Neo4jEpisodeStore,
+) -> DrivePoller:
+    client = create_drive_client(config, state)
+    return DrivePoller(client, episode_store, state, config)
+
+
+def create_calendar_poller(
+    config: GraphitiConfig,
+    state: GraphitiStateStore,
+    episode_store: Neo4jEpisodeStore,
+) -> CalendarPoller:
+    client = create_calendar_client(config, state)
+    return CalendarPoller(client, episode_store, state, config.calendar_ids, config)
+
+
+POLLER_FACTORIES: dict[str, Callable[[GraphitiConfig, GraphitiStateStore, Neo4jEpisodeStore], Any]] = {
+    "gmail": create_gmail_poller,
+    "drive": create_drive_poller,
+    "calendar": create_calendar_poller,
+}
+
+
+# ---- default clients ----
+
+
+@dataclass(slots=True)
+class _NoopGmailClient:
+    def list_history(self, start_history_id: str | None) -> Any:
+        from .pollers.gmail import GmailHistoryResult
+
+        return GmailHistoryResult(message_ids=[], latest_history_id=start_history_id or "noop")
+
+    def fallback_fetch(self, newer_than_days: int) -> Any:
+        from .pollers.gmail import GmailHistoryResult
+
+        return GmailHistoryResult(message_ids=[], latest_history_id=f"noop:{newer_than_days}")
+
+    def fetch_message(self, message_id: str) -> Mapping[str, Any]:  # pragma: no cover - defensive
+        return {"id": message_id}
+
+
+@dataclass(slots=True)
+class _NoopDriveClient:
+    def list_changes(self, page_token: str | None) -> Any:
+        from .pollers.drive import DriveChangesResult
+
+        return DriveChangesResult(changes=[], new_page_token=page_token or "noop")
+
+    def fetch_file_content(self, file_id: str, file_metadata: Mapping[str, Any]) -> Any:
+        from .pollers.drive import DriveFileContent
+
+        return DriveFileContent(text=None, metadata={})
+
+
+@dataclass(slots=True)
+class _NoopCalendarClient:
+    def list_events(self, calendar_id: str, sync_token: str | None) -> Any:
+        from .pollers.calendar import CalendarEventsPage
+
+        token = sync_token or f"noop:{calendar_id}"
+        return CalendarEventsPage(events=[], next_sync_token=token)
+
+    def full_sync(self, calendar_id: str) -> Any:
+        from .pollers.calendar import CalendarEventsPage
+
+        return CalendarEventsPage(events=[], next_sync_token=f"noop:{calendar_id}")
+
+
+def create_gmail_client(
+    config: GraphitiConfig, state: GraphitiStateStore
+) -> Any:  # pragma: no cover - default stub
+    return _NoopGmailClient()
+
+
+def create_drive_client(
+    config: GraphitiConfig, state: GraphitiStateStore
+) -> Any:  # pragma: no cover - default stub
+    return _NoopDriveClient()
+
+
+def create_calendar_client(
+    config: GraphitiConfig, state: GraphitiStateStore
+) -> Any:  # pragma: no cover - default stub
+    return _NoopCalendarClient()
+
+
+def create_slack_client(
+    config: GraphitiConfig, state: GraphitiStateStore
+) -> Any:  # pragma: no cover - default stub
+    from .pollers.slack import NullSlackClient
+
+    return NullSlackClient()
 
 
 COMMAND_HANDLERS = {
     "status": cmd_status,
+    "sync": lambda args: args.func(args),
 }
 
 

--- a/graphiti/config.py
+++ b/graphiti/config.py
@@ -22,6 +22,8 @@ class GraphitiConfig:
     poll_slack_active_seconds: int = 30
     poll_slack_idle_seconds: int = 3600
     gmail_fallback_days: int = 7
+    slack_channel_allowlist: tuple[str, ...] = ()
+    calendar_ids: tuple[str, ...] = ("primary",)
 
     @classmethod
     def from_mapping(
@@ -59,7 +61,22 @@ class GraphitiConfig:
             gmail_fallback_days=get_int(
                 "GMAIL_FALLBACK_DAYS", defaults.gmail_fallback_days
             ),
+            slack_channel_allowlist=_parse_csv(
+                values.get("SLACK_CHANNEL_ALLOWLIST"), defaults.slack_channel_allowlist
+            ),
+            calendar_ids=_parse_csv(
+                values.get("CALENDAR_IDS"), defaults.calendar_ids
+            ),
         )
+
+
+def _parse_csv(raw: Optional[str], default: tuple[str, ...]) -> tuple[str, ...]:
+    if raw is None:
+        return default
+    items = [item.strip() for item in raw.split(",") if item.strip()]
+    if not items:
+        return ()
+    return tuple(dict.fromkeys(items))
 
 
 def _parse_dotenv(path: Path) -> Dict[str, str]:

--- a/graphiti/cursor.py
+++ b/graphiti/cursor.py
@@ -1,0 +1,253 @@
+"""Cursor tool integration for Graphiti."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Callable, Mapping
+
+
+class GraphitiQueryService:
+    """High-level query helpers backed by Neo4j."""
+
+    def __init__(self, driver: Any, *, group_id: str) -> None:
+        self._driver = driver
+        self._group_id = group_id
+
+    def hybrid_search(self, query: str, *, limit: int = 10) -> list[Mapping[str, Any]]:
+        if not isinstance(query, str) or not query.strip():
+            raise ValueError("Query must be a non-empty string")
+        if limit <= 0:
+            raise ValueError("Limit must be positive")
+        params = {"group_id": self._group_id, "query": query, "limit": limit}
+        with self._driver.session() as session:
+            return session.execute_read(self._query_hybrid, params)
+
+    def as_of(
+        self,
+        source: str,
+        native_id: str,
+        as_of: datetime,
+    ) -> Mapping[str, Any] | None:
+        if not source or not native_id:
+            raise ValueError("source and native_id are required")
+        params = {
+            "group_id": self._group_id,
+            "source": source,
+            "native_id": native_id,
+            "as_of": as_of.isoformat(),
+        }
+        with self._driver.session() as session:
+            return session.execute_read(self._query_as_of, params)
+
+    def shortest_path(
+        self,
+        source_native_id: str,
+        target_native_id: str,
+        *,
+        source: str,
+        max_depth: int = 10,
+    ) -> list[Mapping[str, Any]]:
+        if not source_native_id or not target_native_id:
+            raise ValueError("source_native_id and target_native_id are required")
+        if max_depth <= 0:
+            raise ValueError("max_depth must be positive")
+        params = {
+            "group_id": self._group_id,
+            "source": source,
+            "source_native_id": source_native_id,
+            "target_native_id": target_native_id,
+            "max_depth": max_depth,
+        }
+        with self._driver.session() as session:
+            return session.execute_read(self._query_shortest_path, params)
+
+    @staticmethod
+    def _query_hybrid(tx, params):  # pragma: no cover - exercised via driver mocks
+        result = tx.run(
+            """
+            MATCH (e:Episode {group_id: $group_id})
+            WHERE (exists(e.text) AND toLower(e.text) CONTAINS toLower($query))
+            RETURN e ORDER BY e.valid_at DESC LIMIT $limit
+            """,
+            **params,
+        )
+        records: list[Mapping[str, Any]] = []
+        for record in result:
+            node = GraphitiQueryService._first_column(record)
+            if node is not None:
+                records.append(GraphitiQueryService._node_to_dict(node))
+        return records
+
+    @staticmethod
+    def _query_as_of(tx, params):  # pragma: no cover - exercised via driver mocks
+        record = tx.run(
+            """
+            MATCH (e:Episode {group_id: $group_id, source: $source, native_id: $native_id})
+            WHERE datetime(e.valid_at) <= datetime($as_of)
+            RETURN e ORDER BY e.valid_at DESC LIMIT 1
+            """,
+            **params,
+        ).single()
+        if not record:
+            return None
+        node = GraphitiQueryService._first_column(record)
+        return GraphitiQueryService._node_to_dict(node) if node is not None else None
+
+    @staticmethod
+    def _query_shortest_path(tx, params):  # pragma: no cover - exercised via driver mocks
+        result = tx.run(
+            """
+            MATCH (start:Episode {group_id: $group_id, source: $source, native_id: $source_native_id})
+            MATCH (target:Episode {group_id: $group_id, source: $source, native_id: $target_native_id})
+            MATCH p = shortestPath((start)-[*..$max_depth]-(target))
+            RETURN [node IN nodes(p) | node] AS nodes
+            """,
+            **params,
+        )
+        record = result.single()
+        if not record:
+            return []
+        nodes = GraphitiQueryService._first_column(record)
+        if isinstance(nodes, (list, tuple)):
+            return [GraphitiQueryService._node_to_dict(node) for node in nodes]
+        if nodes is None:
+            return []
+        return [GraphitiQueryService._node_to_dict(nodes)]
+
+    @staticmethod
+    def _node_to_dict(node: Any) -> Mapping[str, Any]:
+        if hasattr(node, "_properties"):
+            return dict(node._properties)
+        if isinstance(node, Mapping):
+            return dict(node)
+        return {"value": node}
+
+    @staticmethod
+    def _first_column(record: Any) -> Any:
+        if isinstance(record, Mapping):
+            for value in record.values():
+                return value
+            return None
+        if isinstance(record, (list, tuple)):
+            if not record:
+                return None
+            if len(record) == 1:
+                return record[0]
+            return record
+        return record
+
+
+@dataclass
+class CursorTool:
+    name: str
+    description: str
+    schema: Mapping[str, Any]
+    _handler: Callable[..., Mapping[str, Any] | list[Mapping[str, Any]] | None]
+
+    def run(self, **kwargs):
+        params = self._validate(kwargs)
+        return self._handler(**params)
+
+    def _validate(self, params: Mapping[str, Any]) -> Mapping[str, Any]:
+        properties = self.schema.get("properties", {})
+        required = self.schema.get("required", [])
+        validated: dict[str, Any] = {}
+        for field in required:
+            if field not in params:
+                raise ValueError(f"Missing required parameter: {field}")
+        for field, spec in properties.items():
+            if field not in params:
+                continue
+            value = params[field]
+            expected_type = spec.get("type")
+            if expected_type == "string" and not isinstance(value, str):
+                raise ValueError(f"{field} must be a string")
+            if expected_type == "integer" and not isinstance(value, int):
+                raise ValueError(f"{field} must be an integer")
+            validated[field] = value
+        for field in required:
+            validated.setdefault(field, params[field])
+        return validated
+
+
+class GraphitiCursorToolset:
+    """Collection of Cursor tools backed by the query service."""
+
+    def __init__(self, query_service: GraphitiQueryService) -> None:
+        self._service = query_service
+
+    def tools(self) -> list[CursorTool]:
+        return [
+            CursorTool(
+                name="graphiti_hybrid_search",
+                description="Hybrid search across episodes",
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "query": {"type": "string"},
+                        "limit": {"type": "integer"},
+                    },
+                    "required": ["query"],
+                },
+                _handler=self._run_hybrid,
+            ),
+            CursorTool(
+                name="graphiti_as_of",
+                description="Fetch episode as of a timestamp",
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "source": {"type": "string"},
+                        "native_id": {"type": "string"},
+                        "as_of": {"type": "string"},
+                    },
+                    "required": ["source", "native_id", "as_of"],
+                },
+                _handler=self._run_as_of,
+            ),
+            CursorTool(
+                name="graphiti_shortest_path",
+                description="Compute shortest path between two native ids",
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "source": {"type": "string"},
+                        "source_native_id": {"type": "string"},
+                        "target_native_id": {"type": "string"},
+                        "max_depth": {"type": "integer"},
+                    },
+                    "required": ["source", "source_native_id", "target_native_id"],
+                },
+                _handler=self._run_shortest_path,
+            ),
+        ]
+
+    def _run_hybrid(self, query: str, limit: int = 10, **_: Any):
+        return self._service.hybrid_search(query, limit=limit)
+
+    def _run_as_of(self, source: str, native_id: str, as_of: str, **_: Any):
+        parsed = datetime.fromisoformat(as_of)
+        return self._service.as_of(source, native_id, parsed)
+
+    def _run_shortest_path(
+        self,
+        source: str,
+        source_native_id: str,
+        target_native_id: str,
+        max_depth: int = 10,
+        **_: Any,
+    ):
+        return self._service.shortest_path(
+            source_native_id=source_native_id,
+            target_native_id=target_native_id,
+            source=source,
+            max_depth=max_depth,
+        )
+
+
+__all__ = [
+    "GraphitiQueryService",
+    "CursorTool",
+    "GraphitiCursorToolset",
+]
+

--- a/graphiti/mcp/logger.py
+++ b/graphiti/mcp/logger.py
@@ -1,0 +1,114 @@
+"""MCP episode logging utilities."""
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from threading import Lock
+from typing import Deque, Mapping, MutableMapping
+
+from ..config import GraphitiConfig, load_config
+from ..episodes import Episode, Neo4jEpisodeStore
+
+
+@dataclass(slots=True)
+class McpTurn:
+    """Representation of a single MCP conversation turn."""
+
+    message_id: str
+    conversation_id: str
+    role: str
+    content: str | None
+    timestamp: datetime
+    metadata: Mapping[str, object] = field(default_factory=dict)
+
+    def to_episode(self, group_id: str) -> Episode:
+        metadata = dict(self.metadata)
+        metadata.update({
+            "conversation_id": self.conversation_id,
+            "role": self.role,
+        })
+        json_payload: MutableMapping[str, object] = {
+            "message_id": self.message_id,
+            "conversation_id": self.conversation_id,
+            "role": self.role,
+            "timestamp": self.timestamp.isoformat(),
+        }
+        if self.content is not None:
+            json_payload["content"] = self.content
+        if self.metadata:
+            json_payload["metadata"] = dict(self.metadata)
+        return Episode(
+            group_id=group_id,
+            source="mcp",
+            native_id=self.message_id,
+            version=self.timestamp.isoformat(),
+            valid_at=self.timestamp.astimezone(timezone.utc),
+            text=self.content,
+            json=json_payload,
+            metadata=metadata,
+        )
+
+
+@dataclass
+class McpEpisodeLogger:
+    """Asynchronous-friendly logger that batches MCP turns."""
+
+    episode_store: Neo4jEpisodeStore
+    config: GraphitiConfig | None = None
+    queue_limit: int = 1000
+
+    def __post_init__(self) -> None:
+        self._config = self.config or load_config()
+        if self.episode_store.group_id != self._config.group_id:
+            raise ValueError("Episode store group_id does not match configuration group_id")
+        self._queue: Deque[McpTurn] = deque()
+        self._lock = Lock()
+
+    def log_turn(self, turn: McpTurn) -> None:
+        """Queue a turn for persistence."""
+
+        with self._lock:
+            if len(self._queue) >= self.queue_limit:
+                self._queue.popleft()
+            self._queue.append(turn)
+
+    def drain(self) -> list[McpTurn]:
+        """Drain the queue and return the collected turns."""
+
+        with self._lock:
+            items = list(self._queue)
+            self._queue.clear()
+        return items
+
+    def flush(self) -> int:
+        """Persist queued turns to the episode store."""
+
+        turns = self.drain()
+        if not turns:
+            return 0
+        processed = 0
+        failures: list[tuple[McpTurn, Exception]] = []
+        for turn in turns:
+            episode = turn.to_episode(self._config.group_id)
+            try:
+                self.episode_store.upsert_episode(episode)
+                processed += 1
+            except Exception as exc:  # pragma: no cover - defensive
+                failures.append((turn, exc))
+        if failures:
+            with self._lock:
+                for turn, _ in reversed(failures):
+                    if len(self._queue) < self.queue_limit:
+                        self._queue.appendleft(turn)
+            first_error = failures[0][1]
+            raise RuntimeError("Failed to persist MCP turns") from first_error
+        return processed
+
+    def pending(self) -> int:
+        with self._lock:
+            return len(self._queue)
+
+
+__all__ = ["McpTurn", "McpEpisodeLogger"]
+

--- a/graphiti/pollers/__init__.py
+++ b/graphiti/pollers/__init__.py
@@ -1,8 +1,9 @@
-"""Poller implementations for Gmail, Drive, and Calendar."""
+"""Poller implementations for data sources."""
 
 from .calendar import CalendarPoller, CalendarSyncTokenExpired
 from .drive import DrivePoller
 from .gmail import GmailPoller, GmailHistoryNotFound
+from .slack import SlackPoller, SlackRateLimited
 
 __all__ = [
     "CalendarPoller",
@@ -10,4 +11,6 @@ __all__ = [
     "DrivePoller",
     "GmailPoller",
     "GmailHistoryNotFound",
+    "SlackPoller",
+    "SlackRateLimited",
 ]

--- a/graphiti/pollers/slack.py
+++ b/graphiti/pollers/slack.py
@@ -1,0 +1,290 @@
+"""Slack poller implementation."""
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Iterable, Mapping, MutableMapping, Protocol
+
+from ..config import GraphitiConfig, load_config
+from ..episodes import Episode, Neo4jEpisodeStore
+from ..state import GraphitiStateStore
+
+
+class SlackRateLimited(Exception):
+    """Raised when Slack responds with a rate limit error."""
+
+    def __init__(self, retry_after: float | None = None) -> None:
+        super().__init__("Slack API rate limited")
+        self.retry_after = max(retry_after or 1.0, 0.1)
+
+
+class SlackClient(Protocol):  # pragma: no cover - protocol definition
+    def list_channels(self) -> Iterable[Mapping[str, object]]: ...
+
+    def fetch_channel_history(
+        self, channel_id: str, oldest_ts: str | None
+    ) -> Iterable[Mapping[str, object]]: ...
+
+    def fetch_thread_replies(
+        self, channel_id: str, thread_ts: str, oldest_ts: str | None
+    ) -> Iterable[Mapping[str, object]]: ...
+
+
+@dataclass(slots=True)
+class SlackPoller:
+    """Poll Slack conversations, capturing threads and messages."""
+
+    client: SlackClient
+    episode_store: Neo4jEpisodeStore
+    state_store: GraphitiStateStore
+    allowlist: Iterable[str] | None = None
+    config: GraphitiConfig | None = None
+    max_retries: int = 3
+    _config: GraphitiConfig = field(init=False)
+    _group_id: str = field(init=False)
+    _allowlist: set[str] = field(init=False)
+
+    def __post_init__(self) -> None:
+        self._config = self.config or load_config()
+        if self.episode_store.group_id != self._config.group_id:
+            raise ValueError("Episode store group_id does not match configuration group_id")
+        self._group_id = self._config.group_id
+        allow = [item.lower() for item in self.allowlist or self._config.slack_channel_allowlist]
+        self._allowlist = set(allow)
+
+    def run_once(self) -> int:
+        state = self.state_store.load_state()
+        slack_state = state.get("slack") if isinstance(state, Mapping) else {}
+        if not isinstance(slack_state, Mapping):
+            slack_state = {}
+
+        channels_state = slack_state.get("channels") if isinstance(slack_state, Mapping) else {}
+        if not isinstance(channels_state, Mapping):
+            channels_state = {}
+
+        channels = self._resolve_channels(channels_state)
+        if not channels:
+            channels = self._inventory_channels()
+
+        channel_checkpoints = slack_state.get("checkpoints") if isinstance(slack_state, Mapping) else {}
+        if not isinstance(channel_checkpoints, Mapping):
+            channel_checkpoints = {}
+        thread_checkpoints = slack_state.get("threads") if isinstance(slack_state, Mapping) else {}
+        if not isinstance(thread_checkpoints, Mapping):
+            thread_checkpoints = {}
+
+        processed = 0
+        updated_channels: dict[str, Mapping[str, object]] = {}
+        updated_checkpoints: dict[str, str] = {}
+        updated_threads: dict[str, MutableMapping[str, str]] = {
+            channel_id: dict(checks) if isinstance(checks, Mapping) else {}
+            for channel_id, checks in thread_checkpoints.items()
+            if isinstance(channel_id, str)
+        }
+
+        for channel_id, metadata in channels.items():
+            updated_channels[channel_id] = metadata
+            oldest = str(channel_checkpoints.get(channel_id)) if channel_checkpoints.get(channel_id) else None
+            messages = self._call_with_backoff(
+                self.client.fetch_channel_history, channel_id, oldest
+            )
+            channel_max_ts = oldest
+            for message in messages:
+                episode = self._normalize_message(channel_id, metadata, message)
+                if episode is None:
+                    continue
+                self.episode_store.upsert_episode(episode)
+                processed += 1
+                channel_max_ts = self._max_ts(channel_max_ts, episode.version)
+                thread_ts = self._thread_ts(message)
+                if thread_ts and thread_ts != episode.version:
+                    processed += self._process_thread(
+                        channel_id,
+                        metadata,
+                        thread_ts,
+                        updated_threads,
+                    )
+            if channel_max_ts:
+                updated_checkpoints[channel_id] = channel_max_ts
+
+        payload = {
+            "slack": {
+                "channels": updated_channels,
+                "checkpoints": updated_checkpoints,
+                "threads": updated_threads,
+                "last_run_at": datetime.now(timezone.utc).isoformat(),
+            }
+        }
+        self.state_store.update_state(payload)
+        return processed
+
+    def _inventory_channels(self) -> dict[str, Mapping[str, object]]:
+        channels = self.client.list_channels()
+        filtered = {}
+        for channel in channels:
+            if not isinstance(channel, Mapping):
+                continue
+            channel_id = str(channel.get("id"))
+            name = str(channel.get("name", ""))
+            if not channel_id:
+                continue
+            if self._allowlist and not self._channel_allowed(channel_id, name):
+                continue
+            filtered[channel_id] = dict(channel)
+        return filtered
+
+    def _resolve_channels(self, stored: Mapping[str, Mapping[str, object]]) -> dict[str, Mapping[str, object]]:
+        channels: dict[str, Mapping[str, object]] = {}
+        for channel_id, metadata in stored.items():
+            if not isinstance(metadata, Mapping):
+                continue
+            name = str(metadata.get("name", ""))
+            if self._allowlist and not self._channel_allowed(channel_id, name):
+                continue
+            channels[str(channel_id)] = dict(metadata)
+        return channels
+
+    def _channel_allowed(self, channel_id: str, name: str) -> bool:
+        if not self._allowlist:
+            return True
+        return channel_id.lower() in self._allowlist or name.lower() in self._allowlist
+
+    def _normalize_message(
+        self,
+        channel_id: str,
+        metadata: Mapping[str, object],
+        message: Mapping[str, object],
+    ) -> Episode | None:
+        if not isinstance(message, Mapping):
+            return None
+        if message.get("type") not in {None, "message"}:
+            return None
+        subtype = message.get("subtype")
+        if isinstance(subtype, str) and subtype:
+            return None
+        ts = message.get("ts")
+        if not isinstance(ts, str) or not ts:
+            return None
+        user = message.get("user")
+        if not isinstance(user, str):
+            user = None
+        text = message.get("text")
+        if text is not None and not isinstance(text, str):
+            text = str(text)
+        valid_at = self._parse_ts(ts)
+        native_id = f"{channel_id}:{ts}"
+        json_payload = dict(message)
+        metadata_payload = {
+            "channel_id": channel_id,
+            "channel_name": metadata.get("name"),
+            "user": user,
+            "thread_ts": message.get("thread_ts"),
+            "tombstone": False,
+        }
+        return Episode(
+            group_id=self._group_id,
+            source="slack",
+            native_id=native_id,
+            version=ts,
+            valid_at=valid_at,
+            text=text,
+            json=json_payload,
+            metadata=metadata_payload,
+        )
+
+    def _process_thread(
+        self,
+        channel_id: str,
+        metadata: Mapping[str, object],
+        thread_ts: str,
+        thread_checkpoints: MutableMapping[str, MutableMapping[str, str]],
+    ) -> int:
+        channel_threads = thread_checkpoints.setdefault(channel_id, {})
+        oldest = channel_threads.get(thread_ts)
+        replies = self._call_with_backoff(
+            self.client.fetch_thread_replies, channel_id, thread_ts, oldest
+        )
+        processed = 0
+        thread_max_ts = oldest
+        for reply in replies:
+            if not isinstance(reply, Mapping):
+                continue
+            ts = reply.get("ts")
+            if not isinstance(ts, str) or ts == thread_ts:
+                continue
+            episode = self._normalize_message(channel_id, metadata, reply)
+            if episode is None:
+                continue
+            self.episode_store.upsert_episode(episode)
+            processed += 1
+            thread_max_ts = self._max_ts(thread_max_ts, episode.version)
+        if thread_max_ts:
+            channel_threads[thread_ts] = thread_max_ts
+        return processed
+
+    def _call_with_backoff(self, func, *args):
+        delay = 1.0
+        for attempt in range(self.max_retries):
+            try:
+                result = func(*args)
+                return list(result)
+            except SlackRateLimited as exc:
+                sleep_for = max(delay, exc.retry_after)
+                time.sleep(sleep_for)
+                delay = min(sleep_for * 2, 60.0)
+        result = func(*args)
+        return list(result)
+
+    @staticmethod
+    def _parse_ts(ts: str) -> datetime:
+        try:
+            seconds = float(ts)
+        except (TypeError, ValueError):  # pragma: no cover - defensive
+            seconds = 0.0
+        return datetime.fromtimestamp(seconds, tz=timezone.utc)
+
+    @staticmethod
+    def _thread_ts(message: Mapping[str, object]) -> str | None:
+        value = message.get("thread_ts")
+        return str(value) if isinstance(value, str) and value else None
+
+    @staticmethod
+    def _max_ts(current: str | None, candidate: str) -> str:
+        if current is None:
+            return candidate
+        try:
+            current_f = float(current)
+            candidate_f = float(candidate)
+            return candidate if candidate_f > current_f else current
+        except ValueError:  # pragma: no cover - defensive
+            return candidate
+
+
+@dataclass(slots=True)
+class NullSlackClient:
+    """Default Slack client that performs no operations."""
+
+    channels: tuple[Mapping[str, object], ...] = field(default_factory=tuple)
+
+    def list_channels(self) -> Iterable[Mapping[str, object]]:
+        return list(self.channels)
+
+    def fetch_channel_history(
+        self, channel_id: str, oldest_ts: str | None
+    ) -> Iterable[Mapping[str, object]]:
+        return []
+
+    def fetch_thread_replies(
+        self, channel_id: str, thread_ts: str, oldest_ts: str | None
+    ) -> Iterable[Mapping[str, object]]:
+        return []
+
+
+__all__ = [
+    "SlackPoller",
+    "SlackClient",
+    "SlackRateLimited",
+    "NullSlackClient",
+]
+

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11,17 +11,125 @@ def test_cli_status_outputs_json(monkeypatch, tmp_path, capsys):
     monkeypatch.setattr(pathlib.Path, "home", lambda: tmp_path)
     state_store = GraphitiStateStore()
     monkeypatch.setattr(cli, "GraphitiStateStore", lambda: state_store)
-    monkeypatch.setattr(cli, "load_config", mock.Mock(return_value=mock.Mock(
-        neo4j_uri="bolt://localhost:7687",
-        neo4j_user="neo4j",
-        group_id="group",
-        poll_gmail_drive_calendar_seconds=3600,
-        poll_slack_active_seconds=30,
-        poll_slack_idle_seconds=3600,
-        gmail_fallback_days=7,
-    )))
+    monkeypatch.setattr(
+        cli,
+        "load_config",
+        mock.Mock(
+            return_value=mock.Mock(
+                neo4j_uri="bolt://localhost:7687",
+                neo4j_user="neo4j",
+                group_id="group",
+                poll_gmail_drive_calendar_seconds=3600,
+                poll_slack_active_seconds=30,
+                poll_slack_idle_seconds=3600,
+                gmail_fallback_days=7,
+                calendar_ids=("primary",),
+                slack_channel_allowlist=(),
+            )
+        ),
+    )
 
     exit_code = cli.main(["status"])
     assert exit_code == 0
     data = json.loads(capsys.readouterr().out)
     assert data["state_directory"] == str(state_store.base_dir)
+
+
+def _stub_episode_store():
+    class _Store:
+        group_id = "group"
+
+    return _Store()
+
+
+def test_cli_sync_gmail_once(monkeypatch, tmp_path, capsys):
+    monkeypatch.setattr(pathlib.Path, "home", lambda: tmp_path)
+    monkeypatch.setattr(cli, "create_episode_store", lambda config: _stub_episode_store())
+    monkeypatch.setattr(cli, "close_episode_store", lambda store: None)
+
+    poller_mock = mock.Mock()
+    poller_mock.run_once.return_value = 5
+
+    def factory(config, state, store):
+        return poller_mock
+
+    monkeypatch.setitem(cli.POLLER_FACTORIES, "gmail", factory)
+
+    exit_code = cli.main(["sync", "gmail", "--once"])
+    assert exit_code == 0
+    poller_mock.run_once.assert_called_once()
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["processed"] == 5
+
+
+def test_cli_sync_slack_list_channels(monkeypatch, tmp_path, capsys):
+    monkeypatch.setattr(pathlib.Path, "home", lambda: tmp_path)
+    state_store = GraphitiStateStore()
+    monkeypatch.setattr(cli, "GraphitiStateStore", lambda: state_store)
+    monkeypatch.setattr(cli, "create_episode_store", lambda config: _stub_episode_store())
+    monkeypatch.setattr(cli, "close_episode_store", lambda store: None)
+
+    slack_client = mock.Mock()
+    slack_client.list_channels.return_value = [
+        {"id": "C1", "name": "general"},
+        {"id": "C2", "name": "random"},
+    ]
+    monkeypatch.setattr(cli, "create_slack_client", lambda config, state: slack_client)
+
+    exit_code = cli.main(["sync", "slack", "--list-channels"])
+    assert exit_code == 0
+    output = json.loads(capsys.readouterr().out)
+    assert len(output) == 2
+    state = state_store.load_state()["slack"]
+    assert "C1" in state["channels"]
+
+
+def test_cli_sync_status(monkeypatch, tmp_path, capsys):
+    monkeypatch.setattr(pathlib.Path, "home", lambda: tmp_path)
+    store = GraphitiStateStore()
+    store.update_state({
+        "gmail": {"last_run_at": "2024-01-01T00:00:00Z", "last_history_id": "123"}
+    })
+    monkeypatch.setattr(cli, "GraphitiStateStore", lambda: store)
+
+    exit_code = cli.main(["sync", "status"])
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["gmail"]["checkpoint"]["last_history_id"] == "123"
+
+
+def test_cli_sync_scheduler_once(monkeypatch, tmp_path, capsys):
+    monkeypatch.setattr(pathlib.Path, "home", lambda: tmp_path)
+    monkeypatch.setattr(cli, "create_episode_store", lambda config: _stub_episode_store())
+    monkeypatch.setattr(cli, "close_episode_store", lambda store: None)
+
+    def factory(name):
+        poller = mock.Mock()
+        poller.run_once.return_value = 1
+        return poller
+
+    def gmail_factory(config, state, store):
+        return factory("gmail")
+
+    def drive_factory(config, state, store):
+        return factory("drive")
+
+    def calendar_factory(config, state, store):
+        return factory("calendar")
+
+    monkeypatch.setitem(cli.POLLER_FACTORIES, "gmail", gmail_factory)
+    monkeypatch.setitem(cli.POLLER_FACTORIES, "drive", drive_factory)
+    monkeypatch.setitem(cli.POLLER_FACTORIES, "calendar", calendar_factory)
+
+    slack_poller = mock.Mock()
+    slack_poller.run_once.return_value = 2
+    monkeypatch.setattr(cli, "create_slack_client", lambda config, state: mock.Mock())
+
+    monkeypatch.setattr(
+        cli, "SlackPoller", lambda client, store, state, allowlist: slack_poller
+    )
+
+    exit_code = cli.main(["sync", "scheduler", "--once"])
+    assert exit_code == 0
+    metrics = json.loads(capsys.readouterr().out)["metrics"]
+    assert {entry["source"] for entry in metrics} == {"gmail", "drive", "calendar", "slack"}

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,5 +1,6 @@
 import os
 from pathlib import Path
+import os
 
 import pytest
 
@@ -29,3 +30,15 @@ def test_defaults_when_missing(tmp_path: Path) -> None:
     config = load_config(dotenv_path=tmp_path / ".env", environ={})
     assert isinstance(config, GraphitiConfig)
     assert config.group_id == "mike_assistant"
+    assert config.slack_channel_allowlist == ()
+    assert config.calendar_ids == ("primary",)
+
+
+def test_parse_csv_overrides(tmp_path: Path) -> None:
+    dotenv = tmp_path / ".env"
+    dotenv.write_text(
+        "SLACK_CHANNEL_ALLOWLIST=C1,C2, C2 ,C3\nCALENDAR_IDS=primary,team\n"
+    )
+    config = load_config(dotenv_path=dotenv, environ={})
+    assert config.slack_channel_allowlist == ("C1", "C2", "C3")
+    assert config.calendar_ids == ("primary", "team")

--- a/tests/test_cursor_tools.py
+++ b/tests/test_cursor_tools.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from graphiti.cursor import CursorTool, GraphitiCursorToolset, GraphitiQueryService
+
+
+class FakeNode:
+    def __init__(self, properties):
+        self._properties = properties
+
+
+class FakeResult:
+    def __init__(self, records):
+        self._records = records
+
+    def __iter__(self):
+        return iter(self._records)
+
+    def single(self):
+        if not self._records:
+            return None
+        return self._records[0]
+
+
+class FakeTx:
+    def __init__(self, records):
+        self._records = records
+        self.last_query = None
+        self.last_params = None
+
+    def run(self, statement, **params):
+        self.last_query = statement
+        self.last_params = params
+        return FakeResult(self._records)
+
+
+class FakeSession:
+    def __init__(self, records):
+        self.records = records
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def execute_read(self, func, params):
+        tx = FakeTx(self.records)
+        return func(tx, params)
+
+
+class FakeDriver:
+    def __init__(self, records):
+        self.records = records
+
+    def session(self):
+        return FakeSession(self.records)
+
+
+@pytest.fixture()
+def driver():
+    return FakeDriver([[FakeNode({"episode_id": "1", "text": "hello"})]])
+
+
+def test_hybrid_search(driver):
+    service = GraphitiQueryService(driver, group_id="group")
+    results = service.hybrid_search("hello", limit=5)
+    assert results[0]["episode_id"] == "1"
+
+
+def test_as_of_returns_none(driver):
+    driver.records = []
+    service = GraphitiQueryService(driver, group_id="group")
+    result = service.as_of("gmail", "native", datetime.now(timezone.utc))
+    assert result is None
+
+
+def test_shortest_path(driver):
+    driver.records = [[FakeNode({"episode_id": "1"}), FakeNode({"episode_id": "2"})]]
+    service = GraphitiQueryService(driver, group_id="group")
+    result = service.shortest_path("A", "B", source="gmail", max_depth=5)
+    assert [node["episode_id"] for node in result] == ["1", "2"]
+
+
+def test_cursor_tool_validation():
+    tool = CursorTool(
+        name="demo",
+        description="",
+        schema={"properties": {"name": {"type": "string"}}, "required": ["name"]},
+        _handler=lambda **params: params,
+    )
+    with pytest.raises(ValueError):
+        tool.run()
+    with pytest.raises(ValueError):
+        tool.run(name=123)
+    assert tool.run(name="valid")["name"] == "valid"
+
+
+def test_toolset_dispatch(driver):
+    driver.records = [[FakeNode({"episode_id": "1", "text": "hello"})]]
+    service = GraphitiQueryService(driver, group_id="group")
+    toolset = GraphitiCursorToolset(service)
+    tools = {tool.name: tool for tool in toolset.tools()}
+    hybrid = tools["graphiti_hybrid_search"]
+    assert hybrid.run(query="hello")
+    with pytest.raises(ValueError):
+        tools["graphiti_as_of"].run(source="gmail", native_id="id")
+    result = tools["graphiti_as_of"].run(
+        source="gmail", native_id="id", as_of=datetime.now(timezone.utc).isoformat()
+    )
+    assert result == driver.records[0][0]._properties

--- a/tests/test_mcp_logger.py
+++ b/tests/test_mcp_logger.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from graphiti.config import GraphitiConfig
+from graphiti.mcp.logger import McpEpisodeLogger, McpTurn
+
+
+class InMemoryEpisodeStore:
+    def __init__(self, group_id: str) -> None:
+        self.group_id = group_id
+        self.saved = []
+        self.raise_error = False
+
+    def upsert_episode(self, episode):
+        if self.raise_error:
+            raise RuntimeError("boom")
+        self.saved.append(episode)
+
+
+@pytest.fixture()
+def turn() -> McpTurn:
+    return McpTurn(
+        message_id="msg1",
+        conversation_id="conv",
+        role="user",
+        content="Hello",
+        timestamp=datetime(2024, 1, 1, tzinfo=timezone.utc),
+        metadata={"foo": "bar"},
+    )
+
+
+def test_logger_flushes_turns(turn):
+    store = InMemoryEpisodeStore("group")
+    logger = McpEpisodeLogger(store, GraphitiConfig(group_id="group"))
+    logger.log_turn(turn)
+    assert logger.pending() == 1
+    processed = logger.flush()
+    assert processed == 1
+    assert store.saved[0].metadata["conversation_id"] == "conv"
+    assert logger.pending() == 0
+
+
+def test_logger_trims_queue(turn):
+    store = InMemoryEpisodeStore("group")
+    logger = McpEpisodeLogger(store, GraphitiConfig(group_id="group"), queue_limit=1)
+    logger.log_turn(turn)
+    logger.log_turn(turn)
+    assert logger.pending() == 1
+
+
+def test_logger_requeues_on_failure(turn):
+    store = InMemoryEpisodeStore("group")
+    store.raise_error = True
+    logger = McpEpisodeLogger(store, GraphitiConfig(group_id="group"))
+    logger.log_turn(turn)
+    with pytest.raises(RuntimeError):
+        logger.flush()
+    assert logger.pending() == 1

--- a/tests/test_slack_poller.py
+++ b/tests/test_slack_poller.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable, Mapping
+import time
+
+import pytest
+
+from graphiti.config import GraphitiConfig
+from graphiti.pollers.slack import NullSlackClient, SlackPoller, SlackRateLimited
+from graphiti.state import GraphitiStateStore
+
+
+class InMemoryEpisodeStore:
+    def __init__(self, group_id: str) -> None:
+        self.group_id = group_id
+        self.episodes = []
+
+    def upsert_episode(self, episode):
+        self.episodes.append(episode)
+
+
+class FakeSlackClient(NullSlackClient):
+    def __init__(self, channels: Iterable[Mapping[str, object]]):
+        super().__init__(tuple(dict(channel) for channel in channels))
+        self.histories: dict[str, list[Mapping[str, object]]] = {}
+        self.threads: dict[tuple[str, str], list[Mapping[str, object]]] = {}
+        self.history_calls: list[tuple[str, str | None]] = []
+        self.thread_calls: list[tuple[str, str, str | None]] = []
+        self._rate_limit_next = False
+
+    def queue_history(self, channel_id: str, messages: Iterable[Mapping[str, object]]):
+        self.histories[channel_id] = list(messages)
+
+    def queue_thread(self, channel_id: str, thread_ts: str, messages: Iterable[Mapping[str, object]]):
+        self.threads[(channel_id, thread_ts)] = list(messages)
+
+    def fetch_channel_history(self, channel_id: str, oldest_ts: str | None):
+        self.history_calls.append((channel_id, oldest_ts))
+        if self._rate_limit_next:
+            self._rate_limit_next = False
+            raise SlackRateLimited(0)
+        return self.histories.get(channel_id, [])
+
+    def fetch_thread_replies(self, channel_id: str, thread_ts: str, oldest_ts: str | None):
+        self.thread_calls.append((channel_id, thread_ts, oldest_ts))
+        return self.threads.get((channel_id, thread_ts), [])
+
+    def trigger_rate_limit(self) -> None:
+        self._rate_limit_next = True
+
+
+@pytest.fixture()
+def state_store(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> GraphitiStateStore:
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    return GraphitiStateStore()
+
+
+def test_slack_poller_processes_messages_and_threads(state_store, monkeypatch):
+    config = GraphitiConfig(group_id="group")
+    episode_store = InMemoryEpisodeStore(group_id="group")
+
+    channels = ({"id": "C1", "name": "general"},)
+    client = FakeSlackClient(channels)
+    ts = str(datetime(2024, 1, 1, tzinfo=timezone.utc).timestamp())
+    client.queue_history(
+        "C1",
+        [
+            {
+                "ts": ts,
+                "text": "Hello",
+                "user": "U1",
+                "thread_ts": ts,
+            },
+            {
+                "ts": "1704067201.0",
+                "text": "Follow up",
+                "user": "U2",
+                "thread_ts": ts,
+            },
+        ],
+    )
+    client.queue_thread(
+        "C1",
+        ts,
+        [
+            {"ts": ts, "text": "Hello", "user": "U1", "thread_ts": ts},
+            {"ts": "1704067300.0", "text": "Thread reply", "user": "U3", "thread_ts": ts},
+        ],
+    )
+
+    poller = SlackPoller(client, episode_store, state_store, config=config)
+    processed = poller.run_once()
+
+    assert processed == 3
+    assert len(episode_store.episodes) == 3
+    state = state_store.load_state()["slack"]
+    assert state["checkpoints"]["C1"] == "1704067201.0"
+    assert state["threads"]["C1"][ts] == "1704067300.0"
+
+
+def test_slack_poller_honors_allowlist(state_store):
+    config = GraphitiConfig(group_id="group", slack_channel_allowlist=("restricted",))
+    episode_store = InMemoryEpisodeStore(group_id="group")
+    client = FakeSlackClient(({"id": "C1", "name": "general"}, {"id": "C2", "name": "restricted"}))
+    poller = SlackPoller(client, episode_store, state_store, config=config)
+    state_store.update_state({"slack": {"channels": {"C1": {"name": "general"}, "C2": {"name": "restricted"}}}})
+    processed = poller.run_once()
+    assert processed == 0
+    assert client.history_calls[0][0] == "C2"
+
+
+def test_slack_poller_handles_rate_limit(state_store, monkeypatch):
+    config = GraphitiConfig(group_id="group")
+    episode_store = InMemoryEpisodeStore(group_id="group")
+    client = FakeSlackClient(({"id": "C1", "name": "general"},))
+    client.queue_history("C1", [{"ts": "1.0", "text": "Msg", "user": "U1"}])
+    client.trigger_rate_limit()
+
+    slept = []
+
+    def fake_sleep(value):
+        slept.append(value)
+
+    monkeypatch.setattr(time, "sleep", fake_sleep)
+
+    poller = SlackPoller(client, episode_store, state_store, config=config)
+    processed = poller.run_once()
+    assert processed == 1
+    assert slept and slept[0] >= 1.0
+
+
+def test_slack_poller_skips_bots(state_store):
+    config = GraphitiConfig(group_id="group")
+    episode_store = InMemoryEpisodeStore(group_id="group")
+    client = FakeSlackClient(({"id": "C1", "name": "general"},))
+    client.queue_history(
+        "C1",
+        [
+            {"ts": "1.0", "text": "bot", "subtype": "bot_message"},
+            {"ts": "2.0", "text": "user", "user": "U1"},
+        ],
+    )
+    poller = SlackPoller(client, episode_store, state_store, config=config)
+    processed = poller.run_once()
+    assert processed == 1
+    assert len(episode_store.episodes) == 1


### PR DESCRIPTION
## Summary
- extend the CLI with sync commands, a scheduler stub, and Slack channel inventory support backed by configurable defaults
- implement the Slack poller with rate limit handling alongside an MCP episode logger and Cursor query service and tools
- add configuration options plus comprehensive unit tests for the new CLI flows, poller behaviour, and query integrations

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dc6ebc130c8330aefd050cf51de69a