### PR TITLE
Improve poller metadata storage and expand setup documentation

### DIFF
--- a/graphiti/cli.py
+++ b/graphiti/cli.py
@@ -165,7 +165,7 @@ def cmd_sync_slack(args: argparse.Namespace) -> int:
                 {
                     "slack": {
                         "channels": {
-                            str(c.get("id")): dict(c)
+                            str(c.get("id")): {"metadata": dict(c)}
                             for c in filtered
                             if isinstance(c, Mapping) and c.get("id")
                         },

--- a/graphiti/mcp/logger.py
+++ b/graphiti/mcp/logger.py
@@ -26,11 +26,13 @@ class McpTurn:
         metadata = dict(self.metadata)
         metadata.update({
             "conversation_id": self.conversation_id,
+            "thread_id": self.conversation_id,
             "role": self.role,
         })
         json_payload: MutableMapping[str, object] = {
             "message_id": self.message_id,
             "conversation_id": self.conversation_id,
+            "thread_id": self.conversation_id,
             "role": self.role,
             "timestamp": self.timestamp.isoformat(),
         }

--- a/graphiti/pollers/calendar.py
+++ b/graphiti/pollers/calendar.py
@@ -97,6 +97,12 @@ class CalendarPoller:
             "recurringEventId": event.get("recurringEventId"),
             "tombstone": status == "cancelled",
         }
+        location = event.get("location")
+        if location:
+            metadata["location"] = location
+        attendees = event.get("attendees")
+        if isinstance(attendees, list) and attendees:
+            metadata["attendees"] = attendees
         json_payload = dict(event)
         if status == "cancelled":
             json_payload = {"cancelled": True, "event": dict(event)}

--- a/graphiti/pollers/drive.py
+++ b/graphiti/pollers/drive.py
@@ -108,13 +108,20 @@ class DrivePoller:
 
         content = self._drive.fetch_file_content(file_id, file_metadata)
         text = content.text
+        revision_id = file_metadata.get("headRevisionId") or file_metadata.get("revisionId")
         metadata = {
             "file_id": file_id,
             "name": file_metadata.get("name"),
             "mimeType": file_metadata.get("mimeType"),
             "webViewLink": file_metadata.get("webViewLink"),
+            "url": file_metadata.get("webViewLink") or file_metadata.get("webContentLink"),
         }
         metadata.update({k: v for k, v in content.metadata.items()})
+        if revision_id and "revisionId" not in metadata:
+            metadata["revisionId"] = revision_id
+        owners = metadata.get("owners") or file_metadata.get("owners")
+        if owners is not None:
+            metadata["owners"] = owners
 
         return Episode(
             group_id=self._group_id,

--- a/graphiti/pollers/gmail.py
+++ b/graphiti/pollers/gmail.py
@@ -114,11 +114,21 @@ class GmailPoller:
                         if isinstance(name, str) and isinstance(value, str):
                             headers[name.lower()] = value
 
+        from_addr = headers.get("from")
+        to_addr = headers.get("to")
+        message_id_header = headers.get("message-id")
+
         metadata = {
             "message_id": message_id,
             "thread_id": thread_id,
             "headers": headers,
         }
+        if from_addr:
+            metadata["from"] = from_addr
+        if to_addr:
+            metadata["to"] = to_addr
+        if message_id_header:
+            metadata["message_id_hdr"] = message_id_header
 
         return Episode(
             group_id=self._group_id,

--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,230 @@
-# Personal Assistant Repository
+# Graphiti Personal & Enterprise Assistant
 
-This repository contains the product requirements document for the **Graphiti** personal and enterprise assistant memory system. The PRD captures goals, architecture, functional requirements, and acceptance criteria for building a local-first knowledge graph that unifies Gmail, Google Drive, Google Calendar, Slack, and MCP/Cursor conversations.
+Graphiti is a local-first knowledge graph that continuously ingests Gmail, Google Drive, Google Calendar, Slack, and MCP/Cursor activity so your assistant can answer time-aware questions. This repository contains the product requirements, task plan, and a full Python reference implementation with pollers, persistence helpers, health checks, and an acceptance harness.
 
-- 📄 [Graphiti Product Requirements Document](docs/graphiti_prd.md)
+The guide below walks a new operator through the entire setup — from installing prerequisites and creating API credentials to running the pollers, verifying health, and backing up state.
+
+## Quick Start Overview
+
+1. Install Python 3.11+, Docker, and the Neo4j database driver.
+2. Launch a local Neo4j instance and configure Graphiti via a `.env` file.
+3. Create OAuth credentials for Google Workspace APIs and generate a user token for Slack.
+4. Store the tokens under `~/.graphiti_sync/` and confirm Graphiti can read them.
+5. Run the Gmail, Drive, Calendar, and Slack pollers once to seed the graph.
+6. Start the optional health endpoint or scheduler and monitor sync status.
+7. Back up the state directory regularly to protect checkpoints and credentials.
+
+Each step is detailed below.
+
+## Prerequisites
+
+- **Operating System:** macOS (primary target) or Linux with Docker installed.
+- **Python:** 3.11 or newer (3.12 tested).
+- **Neo4j:** Local instance reachable at `bolt://localhost:7687` (Docker recipe provided).
+- **Google APIs:** Workspace account with Gmail, Drive, and Calendar enabled plus access to the Google Cloud Console.
+- **Slack:** Workspace admin rights to generate a user OAuth token with read scopes.
+- **Optional:** `uvicorn` (for FastAPI health endpoint) and `pytest` (for running the acceptance harness).
+
+## Step-by-Step Setup
+
+### 1. Clone the repository
+
+```bash
+git clone https://github.com/your-org/graphiti.git
+cd graphiti
+```
+
+### 2. Create and activate a Python environment
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+python -m pip install --upgrade pip
+```
+
+### 3. Install Python dependencies
+
+Install the runtime dependencies (Neo4j driver, FastAPI for health checks, and optional tooling):
+
+```bash
+pip install neo4j fastapi uvicorn pytest
+```
+
+### 4. Start Neo4j locally
+
+Run Neo4j in Docker with an isolated password (change `localgraph` to your secret):
+
+```bash
+docker run -d \
+  --name graphiti-neo4j \
+  -p 7687:7687 -p 7474:7474 \
+  -e NEO4J_AUTH=neo4j/localgraph \
+  neo4j:5
+```
+
+Confirm the service is reachable:
+
+```bash
+cypher-shell -u neo4j -p localgraph "RETURN 1"
+```
+
+### 5. Configure Graphiti via `.env`
+
+Copy the sample below into a `.env` file at the project root and adjust values to match your environment:
+
+```bash
+cat > .env <<'ENV'
+NEO4J_URI=bolt://localhost:7687
+NEO4J_USER=neo4j
+NEO4J_PASS=localgraph
+GROUP_ID=mike_assistant
+POLL_GMAIL_DRIVE_CAL=3600
+POLL_SLACK_ACTIVE=30
+POLL_SLACK_IDLE=3600
+GMAIL_FALLBACK_DAYS=7
+CALENDAR_IDS=primary
+ENV
+```
+
+### 6. Initialise the state directory
+
+Graphiti stores OAuth tokens and poller checkpoints under `~/.graphiti_sync/`. Run the status command once to create the directory with the correct permissions:
+
+```bash
+python -m graphiti.cli status
+```
+
+The command prints the resolved configuration and confirms paths to `tokens.json` and `state.json`.
+
+### 7. Create Google API credentials
+
+1. In the Google Cloud Console, create an OAuth client for Desktop applications.
+2. Download the client secrets JSON and use Google’s OAuth Playground or [`gcloud auth application-default print-access-token`](https://cloud.google.com/sdk/gcloud/reference/auth/application-default/print-access-token) to perform the OAuth consent flow for the scopes:
+   - `https://www.googleapis.com/auth/gmail.readonly`
+   - `https://www.googleapis.com/auth/drive.readonly`
+   - `https://www.googleapis.com/auth/calendar.readonly`
+3. Copy the resulting refresh token and client details into `~/.graphiti_sync/tokens.json` using the structure below:
+
+```json
+{
+  "google": {
+    "client_id": "YOUR_CLIENT_ID",
+    "client_secret": "YOUR_CLIENT_SECRET",
+    "refresh_token": "YOUR_REFRESH_TOKEN",
+    "scopes": [
+      "https://www.googleapis.com/auth/gmail.readonly",
+      "https://www.googleapis.com/auth/drive.readonly",
+      "https://www.googleapis.com/auth/calendar.readonly"
+    ]
+  }
+}
+```
+
+4. Restrict file permissions to the current user (`chmod 600 ~/.graphiti_sync/tokens.json`).
+
+### 8. Generate a Slack user token
+
+1. Visit <https://api.slack.com/apps>, create a new app, and enable the following user token scopes:
+   - `channels:history`, `channels:read`
+   - `groups:history`, `groups:read`
+   - `im:history`, `im:read`
+   - `mpim:history`, `mpim:read`
+2. Install the app to your workspace and copy the generated `xoxp-` token.
+3. Extend `~/.graphiti_sync/tokens.json` with the Slack credentials:
+
+```json
+{
+  "google": { ... },
+  "slack": {
+    "user_token": "xoxp-your-token",
+    "workspace": "your-workspace"
+  }
+}
+```
+
+4. Limit file permissions again (`chmod 600 ~/.graphiti_sync/tokens.json`).
+
+### 9. Verify configuration and inventory Slack channels
+
+List available Slack channels (and persist their metadata/IDs to state):
+
+```bash
+python -m graphiti.cli sync slack --list-channels
+```
+
+The output is a JSON array of channels that Graphiti will poll. You can further restrict ingestion by setting `SLACK_CHANNEL_ALLOWLIST` in `.env` before running this command.
+
+### 10. Run the pollers to seed Graphiti
+
+Execute each poller once to ingest the latest activity:
+
+```bash
+python -m graphiti.cli sync gmail --once
+python -m graphiti.cli sync drive --once
+python -m graphiti.cli sync calendar --once
+python -m graphiti.cli sync slack --once
+```
+
+Each command prints a JSON summary including how many episodes were written and the execution timestamp. Rerun the commands whenever you need a manual refresh.
+
+### 11. (Optional) Log MCP / Cursor turns
+
+Integrate your MCP or Cursor workflow by creating `McpTurn` objects and logging them through `graphiti.mcp.logger.McpEpisodeLogger`. The logger batches turns and writes them via the same episode pipeline used by the pollers.
+
+### 12. Monitor health and scheduling
+
+- **Status dashboard:**
+  ```bash
+  python -m graphiti.cli sync status
+  ```
+  This prints a textual dashboard with the last run time, next due interval, and error counts per source.
+
+- **JSON status:**
+  ```bash
+  python -m graphiti.cli sync status --json
+  ```
+
+- **Health endpoint:**
+  ```bash
+  uvicorn "graphiti.health:create_health_app" --factory --reload
+  ```
+  Visit `http://localhost:8000/health` for a machine-readable summary.
+
+- **Scheduler stub:**
+  ```bash
+  python -m graphiti.cli sync scheduler --once
+  ```
+  This sequentially runs all pollers and prints aggregate metrics. Use the output to wire Graphiti into a `launchd` or cron job.
+
+### 13. Back up and restore state
+
+Create a timestamped archive of `~/.graphiti_sync/`:
+
+```bash
+python -m graphiti.cli backup state --output ~/Backups
+```
+
+Restore from an archive and reapply file permissions automatically:
+
+```bash
+python -m graphiti.cli restore state ~/Backups/graphiti-state-YYYYMMDDHHMMSS.tar.gz
+```
+
+Run the relevant `sync ... --once` commands afterward to resume polling from the restored checkpoints.
+
+### 14. Validate with the acceptance harness (optional)
+
+Developers can run the synthetic end-to-end test harness to confirm the ingestion pipeline:
+
+```bash
+pytest tests/test_acceptance_harness.py
+```
+
+## Additional Documentation
+
+- [Product Requirements](docs/graphiti_prd.md)
+- [Implementation Task Plan](docs/task_plan.md)
+- [Operational Playbook](docs/ops.md)
+- [Deployment Notes](docs/deployment.md)
+
+These documents expand on the architecture, API expectations, and operational procedures described above.


### PR DESCRIPTION
## Summary
- align Gmail, Drive, Calendar, and Slack metadata handling with the PRD, including new Slack checkpoint structure
- add thread identifiers to MCP episode payloads and persist Slack channel metadata from the CLI
- rewrite the README with step-by-step setup guidance for new operators

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dc75e2a330833091242ee0ab17f0f3