### PR TITLE
Add historical loaders, scheduled backups, and log viewer

### DIFF
--- a/graphiti/cli.py
+++ b/graphiti/cli.py
@@ -112,8 +112,16 @@ def cmd_status(_: argparse.Namespace) -> int:
             "poll_slack_active_seconds": config.poll_slack_active_seconds,
             "poll_slack_idle_seconds": config.poll_slack_idle_seconds,
             "gmail_fallback_days": config.gmail_fallback_days,
+            "gmail_backfill_days": config.gmail_backfill_days,
+            "drive_backfill_days": config.drive_backfill_days,
+            "calendar_backfill_days": config.calendar_backfill_days,
+            "slack_backfill_days": config.slack_backfill_days,
             "calendar_ids": list(config.calendar_ids),
             "slack_channel_allowlist": list(config.slack_channel_allowlist),
+            "backup_directory": config.backup_directory,
+            "backup_retention_days": config.backup_retention_days,
+            "log_retention_days": config.log_retention_days,
+            "logs_directory": config.logs_directory,
         },
         "state_directory": str(state.base_dir),
         "tokens_path_exists": state.tokens_path.exists(),
@@ -352,6 +360,13 @@ class _NoopGmailClient:
 @dataclass(slots=True)
 class _NoopDriveClient:
     def list_changes(self, page_token: str | None) -> Any:
+        from .pollers.drive import DriveChangesResult
+
+        return DriveChangesResult(changes=[], new_page_token=page_token or "noop")
+
+    def backfill_changes(
+        self, newer_than_days: int, page_token: str | None = None
+    ) -> Any:
         from .pollers.drive import DriveChangesResult
 
         return DriveChangesResult(changes=[], new_page_token=page_token or "noop")

--- a/graphiti/logs.py
+++ b/graphiti/logs.py
@@ -1,0 +1,153 @@
+"""Lightweight structured logging utilities for the admin and pollers."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from threading import Lock
+from typing import Any, Mapping
+import json
+
+
+@dataclass(frozen=True)
+class LogRecord:
+    """Structured representation of a persisted log entry."""
+
+    timestamp: datetime
+    level: str
+    message: str
+    data: Mapping[str, Any]
+
+    @classmethod
+    def from_json(cls, payload: Mapping[str, Any]) -> "LogRecord":
+        ts_raw = payload.get("timestamp")
+        if not isinstance(ts_raw, str):
+            raise ValueError("Log record missing timestamp")
+        try:
+            timestamp = datetime.fromisoformat(
+                ts_raw.replace("Z", "+00:00") if ts_raw.endswith("Z") else ts_raw
+            ).astimezone(timezone.utc)
+        except ValueError as exc:  # pragma: no cover - defensive parsing
+            raise ValueError(f"Invalid timestamp in log record: {ts_raw!r}") from exc
+        level = str(payload.get("level", "INFO"))
+        message = str(payload.get("message", ""))
+        data = payload.get("data") if isinstance(payload.get("data"), Mapping) else {}
+        return cls(timestamp=timestamp, level=level.upper(), message=message, data=data)
+
+    def to_json(self) -> Mapping[str, Any]:
+        return {
+            "timestamp": self.timestamp.astimezone(timezone.utc).isoformat(),
+            "level": self.level,
+            "message": self.message,
+            "data": dict(self.data),
+        }
+
+
+class GraphitiLogStore:
+    """Persist and retrieve structured log entries with retention controls."""
+
+    def __init__(self, base_dir: Path | str) -> None:
+        self.base_dir = Path(base_dir)
+        self.base_dir.mkdir(parents=True, exist_ok=True)
+        self._lock = Lock()
+
+    def append(
+        self,
+        category: str,
+        message: str,
+        *,
+        level: str = "INFO",
+        data: Mapping[str, Any] | None = None,
+        retention_days: int | None = None,
+    ) -> LogRecord:
+        record = LogRecord(
+            timestamp=datetime.now(timezone.utc),
+            level=level.upper(),
+            message=message,
+            data=dict(data or {}),
+        )
+        path = self._path_for_category(category)
+        payload = record.to_json()
+        line = json.dumps(payload, sort_keys=True)
+        with self._lock:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            with path.open("a", encoding="utf-8") as handle:
+                handle.write(line + "\n")
+            if retention_days is not None:
+                self._prune_file(path, retention_days)
+        return record
+
+    def tail(
+        self,
+        category: str,
+        *,
+        limit: int = 200,
+        since: datetime | None = None,
+    ) -> list[LogRecord]:
+        path = self._path_for_category(category)
+        if not path.exists():
+            return []
+        lines = path.read_text(encoding="utf-8").splitlines()[-max(limit, 0) :]
+        records: list[LogRecord] = []
+        for line in lines:
+            if not line.strip():
+                continue
+            try:
+                payload = json.loads(line)
+                record = LogRecord.from_json(payload)
+            except Exception:  # pragma: no cover - defensive parsing
+                continue
+            if since and record.timestamp < since:
+                continue
+            records.append(record)
+        return records
+
+    def categories(self) -> list[str]:
+        return sorted({path.stem for path in self.base_dir.glob("*.log")})
+
+    def prune(self, retention_days: int) -> None:
+        cutoff = datetime.now(timezone.utc) - timedelta(days=max(retention_days, 0))
+        with self._lock:
+            for path in self.base_dir.glob("*.log"):
+                self._prune_file(path, retention_days, cutoff=cutoff)
+
+    def _path_for_category(self, category: str) -> Path:
+        safe = category.strip().lower() or "default"
+        return self.base_dir / f"{safe}.log"
+
+    def _prune_file(
+        self,
+        path: Path,
+        retention_days: int,
+        *,
+        cutoff: datetime | None = None,
+    ) -> None:
+        if retention_days < 0:
+            return
+        cutoff_dt = cutoff or (
+            datetime.now(timezone.utc) - timedelta(days=retention_days)
+        )
+        if retention_days == 0:
+            path.unlink(missing_ok=True)
+            return
+        if not path.exists():
+            return
+        lines = path.read_text(encoding="utf-8").splitlines()
+        kept: list[str] = []
+        for line in lines:
+            if not line.strip():
+                continue
+            try:
+                payload = json.loads(line)
+                record = LogRecord.from_json(payload)
+            except Exception:  # pragma: no cover - defensive
+                continue
+            if record.timestamp >= cutoff_dt:
+                kept.append(json.dumps(record.to_json(), sort_keys=True))
+        with path.open("w", encoding="utf-8") as handle:
+            handle.write("\n".join(kept))
+            if kept:
+                handle.write("\n")
+
+
+__all__ = ["GraphitiLogStore", "LogRecord"]

--- a/graphiti/maintenance.py
+++ b/graphiti/maintenance.py
@@ -1,0 +1,150 @@
+"""Background maintenance helpers for backups and scheduled tasks."""
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+try:  # pragma: no cover - available on Python 3.9+
+    from zoneinfo import ZoneInfo
+except Exception:  # pragma: no cover - fallback when zoneinfo unavailable
+    ZoneInfo = None  # type: ignore[assignment]
+
+from .config import ConfigStore, GraphitiConfig
+from .logs import GraphitiLogStore
+from .ops import create_state_backup, prune_backup_archives
+from .state import GraphitiStateStore
+
+BACKUP_TZ = ZoneInfo("America/New_York") if ZoneInfo else None
+BACKUP_HOUR = 2
+
+
+def next_backup_run(now: datetime) -> datetime:
+    """Return the UTC timestamp for the next scheduled backup run."""
+
+    if BACKUP_TZ is None:
+        base = now if now.tzinfo else datetime.now(timezone.utc)
+        target = base.replace(hour=BACKUP_HOUR, minute=0, second=0, microsecond=0)
+        if base >= target:
+            target += timedelta(days=1)
+        return target
+
+    local_now = now.astimezone(BACKUP_TZ)
+    target_local = local_now.replace(hour=BACKUP_HOUR, minute=0, second=0, microsecond=0)
+    if local_now >= target_local:
+        target_local += timedelta(days=1)
+    return target_local.astimezone(timezone.utc)
+
+
+class BackupScheduler:
+    """Co-ordinate daily backup creation and pruning with retention policies."""
+
+    def __init__(
+        self,
+        *,
+        state_store: GraphitiStateStore,
+        config_store: ConfigStore,
+        log_store: GraphitiLogStore,
+    ) -> None:
+        self._state_store = state_store
+        self._config_store = config_store
+        self._log_store = log_store
+        self._task: asyncio.Task[None] | None = None
+        self._stop_event: asyncio.Event | None = None
+
+    async def start(self) -> None:
+        if self._task is not None:
+            return
+        self._stop_event = asyncio.Event()
+        self._task = asyncio.create_task(self._run_loop())
+
+    def update_log_store(self, log_store: GraphitiLogStore) -> None:
+        """Swap the log store used for future backup runs."""
+
+        self._log_store = log_store
+
+    async def stop(self) -> None:
+        if self._task is None or self._stop_event is None:
+            return
+        self._stop_event.set()
+        try:
+            await self._task
+        finally:
+            self._task = None
+            self._stop_event = None
+
+    async def trigger(self) -> Path | None:
+        """Run a backup immediately, returning the archive path when successful."""
+
+        config = self._config_store.load()
+        return await self._run_backup(config)
+
+    async def _run_loop(self) -> None:
+        assert self._stop_event is not None
+        while not self._stop_event.is_set():
+            config = self._config_store.load()
+            now = datetime.now(timezone.utc)
+            next_run = next_backup_run(now)
+            wait_seconds = max((next_run - now).total_seconds(), 0)
+            try:
+                await asyncio.wait_for(self._stop_event.wait(), timeout=wait_seconds)
+                return
+            except asyncio.TimeoutError:
+                await self._run_backup(config)
+
+    async def _run_backup(self, config: GraphitiConfig) -> Path | None:
+        destination = Path(config.backup_directory).expanduser()
+        retention = max(config.backup_retention_days, 0)
+        log_retention = max(config.log_retention_days, 0)
+        try:
+            destination.mkdir(parents=True, exist_ok=True)
+        except Exception as exc:  # pragma: no cover - filesystem errors
+            self._log_store.append(
+                "system",
+                f"Failed to prepare backup directory: {exc}",
+                level="ERROR",
+                data={"destination": str(destination)},
+                retention_days=log_retention,
+            )
+            return None
+
+        try:
+            archive = await asyncio.to_thread(
+                create_state_backup, self._state_store, destination=destination
+            )
+            removed = await asyncio.to_thread(
+                prune_backup_archives, destination, retention
+            )
+            timestamp = datetime.now(timezone.utc).isoformat()
+            self._state_store.update_state(
+                {
+                    "backups": {
+                        "last_run_at": timestamp,
+                        "last_archive": str(archive),
+                        "retention_days": retention,
+                        "removed_archives": [str(path) for path in removed],
+                    }
+                }
+            )
+            self._log_store.append(
+                "system",
+                "State backup completed",
+                data={
+                    "archive": str(archive),
+                    "removed": [path.name for path in removed],
+                },
+                retention_days=log_retention,
+            )
+            return archive
+        except Exception as exc:  # pragma: no cover - defensive logging
+            self._log_store.append(
+                "system",
+                f"Backup failed: {exc}",
+                level="ERROR",
+                data={"destination": str(destination)},
+                retention_days=log_retention,
+            )
+            return None
+
+
+__all__ = ["BackupScheduler", "next_backup_run"]

--- a/graphiti/utils.py
+++ b/graphiti/utils.py
@@ -1,0 +1,20 @@
+"""Common helper utilities used across Graphiti modules."""
+from __future__ import annotations
+
+import random
+import time
+
+
+def sleep_with_jitter(base: float = 0.5, jitter: float = 0.25) -> float:
+    """Sleep for a duration around *base* seconds with +/- *jitter* randomness."""
+
+    jitter = max(jitter, 0.0)
+    lower = max(base - jitter, 0.0)
+    upper = max(base + jitter, 0.0)
+    delay = random.uniform(lower, upper)
+    if delay > 0:
+        time.sleep(delay)
+    return delay
+
+
+__all__ = ["sleep_with_jitter"]

--- a/graphiti/web_admin/app.py
+++ b/graphiti/web_admin/app.py
@@ -1,6 +1,8 @@
 """FastAPI application powering the Graphiti admin UI."""
 from __future__ import annotations
 
+import asyncio
+from datetime import datetime, timedelta, timezone
 from html import escape
 from pathlib import Path
 from string import Template
@@ -10,7 +12,19 @@ from fastapi import FastAPI, HTTPException
 from fastapi.responses import HTMLResponse
 from pydantic import BaseModel, Field, validator
 
+from ..cli import (
+    close_episode_store,
+    create_calendar_poller,
+    create_drive_poller,
+    create_episode_store,
+    create_gmail_poller,
+    create_slack_client,
+)
 from ..config import ConfigStore, GraphitiConfig
+from ..logs import GraphitiLogStore
+from ..maintenance import BackupScheduler
+from ..pollers.slack import SlackPoller
+from ..state import GraphitiStateStore
 
 
 class RedactionRule(BaseModel):
@@ -30,6 +44,10 @@ class ConfigPayload(BaseModel):
     poll_slack_active_seconds: int = Field(..., ge=1)
     poll_slack_idle_seconds: int = Field(..., ge=1)
     gmail_fallback_days: int = Field(..., ge=1)
+    gmail_backfill_days: int = Field(..., ge=1)
+    drive_backfill_days: int = Field(..., ge=1)
+    calendar_backfill_days: int = Field(..., ge=1)
+    slack_backfill_days: int = Field(..., ge=1)
     slack_channel_allowlist: list[str] = Field(default_factory=list)
     calendar_ids: list[str] = Field(default_factory=lambda: ["primary"])
     redaction_rules_path: str | None = None
@@ -38,6 +56,10 @@ class ConfigPayload(BaseModel):
     summarization_threshold: int = Field(..., ge=1)
     summarization_max_chars: int = Field(..., ge=1)
     summarization_sentence_count: int = Field(..., ge=1)
+    backup_directory: str = Field(..., min_length=1)
+    backup_retention_days: int = Field(..., ge=0)
+    log_retention_days: int = Field(..., ge=0)
+    logs_directory: str | None = None
 
     @validator("slack_channel_allowlist", "calendar_ids", pre=True)
     def _strip_items(cls, value: Any) -> list[str]:  # noqa: D401,N805
@@ -59,6 +81,15 @@ class ConfigPayload(BaseModel):
             result.append(item)
         return result
 
+    @validator("logs_directory", pre=True)
+    def _empty_to_none(cls, value: Any) -> str | None:  # noqa: D401,N805
+        """Normalise optional path fields."""
+
+        if value is None:
+            return None
+        text = str(value).strip()
+        return text or None
+
     def to_config(self) -> GraphitiConfig:
         return GraphitiConfig.from_json(self.model_dump())
 
@@ -67,11 +98,84 @@ class ConfigPayload(BaseModel):
         return cls(**config.to_json())
 
 
+class ManualLoadPayload(BaseModel):
+    days: int = Field(..., ge=1)
+
+
 def create_app(config_path: Path | None = None) -> FastAPI:
     """Create a FastAPI application exposing the admin UI."""
 
     store = ConfigStore(path=config_path)
+    state_store = GraphitiStateStore()
+    initial_config = store.load()
+    log_store = GraphitiLogStore(_logs_directory(initial_config, state_store))
+    log_store.prune(initial_config.log_retention_days)
+    scheduler = BackupScheduler(
+        state_store=state_store,
+        config_store=store,
+        log_store=log_store,
+    )
+
     app = FastAPI(title="Graphiti Admin", version="1.0.0")
+
+    def _refresh_log_store(config: GraphitiConfig) -> None:
+        nonlocal log_store
+        log_store = GraphitiLogStore(_logs_directory(config, state_store))
+        log_store.prune(config.log_retention_days)
+        scheduler.update_log_store(log_store)
+
+    async def _run_manual_load(source: str, days: int) -> dict[str, Any]:
+        config = store.load()
+        episode_store = create_episode_store(config)
+        processed = 0
+        try:
+            if source == "gmail":
+                poller = create_gmail_poller(config, state_store, episode_store)
+                processed = await asyncio.to_thread(poller.backfill, days)
+            elif source == "drive":
+                poller = create_drive_poller(config, state_store, episode_store)
+                processed = await asyncio.to_thread(poller.backfill, days)
+            elif source == "calendar":
+                poller = create_calendar_poller(
+                    config, state_store, episode_store
+                )
+                processed = await asyncio.to_thread(poller.backfill, days)
+            elif source == "slack":
+                client = create_slack_client(config, state_store)
+                poller = SlackPoller(
+                    client,
+                    episode_store,
+                    state_store,
+                    allowlist=config.slack_channel_allowlist,
+                    config=config,
+                )
+                processed = await asyncio.to_thread(poller.backfill, days)
+            else:  # pragma: no cover - defensive
+                raise HTTPException(status_code=404, detail="Unknown source")
+        finally:
+            close_episode_store(episode_store)
+
+        log_store.append(
+            "episodes",
+            f"{source} backfill processed {processed} episodes",
+            data={"source": source, "days": days},
+            retention_days=config.log_retention_days,
+        )
+        log_store.append(
+            "system",
+            f"Manual {source} backfill completed",
+            data={"processed": processed, "days": days},
+            retention_days=config.log_retention_days,
+        )
+        return {"source": source, "processed": processed, "days": days}
+
+    @app.on_event("startup")
+    async def _startup() -> None:  # pragma: no cover - exercised in integration
+        await scheduler.start()
+
+    @app.on_event("shutdown")
+    async def _shutdown() -> None:  # pragma: no cover - exercised in integration
+        await scheduler.stop()
 
     @app.get("/", response_class=HTMLResponse)
     async def index() -> HTMLResponse:
@@ -90,8 +194,49 @@ def create_app(config_path: Path | None = None) -> FastAPI:
             config = payload.to_config()
         except ValueError as exc:  # pragma: no cover - defensive
             raise HTTPException(status_code=400, detail=str(exc)) from exc
-        store.save(config)
-        return ConfigPayload.from_config(config)
+        saved = store.save(config)
+        _refresh_log_store(saved)
+        return ConfigPayload.from_config(saved)
+
+    @app.post("/api/manual-load/{source}")
+    async def manual_load(source: str, payload: ManualLoadPayload) -> dict[str, Any]:
+        return await _run_manual_load(source, payload.days)
+
+    @app.post("/api/backup/run")
+    async def trigger_backup() -> dict[str, Any]:
+        archive = await scheduler.trigger()
+        config = store.load()
+        message = "Backup triggered"
+        if archive:
+            log_store.append(
+                "system",
+                "Manual backup created",
+                data={"archive": str(archive)},
+                retention_days=config.log_retention_days,
+            )
+        else:
+            message = "Backup request queued"
+        return {"archive": str(archive) if archive else None, "status": message}
+
+    @app.get("/api/logs")
+    async def get_logs(
+        category: str = "system",
+        limit: int = 200,
+        since_days: int | None = None,
+    ) -> dict[str, Any]:
+        config = store.load()
+        since = None
+        if since_days and since_days > 0:
+            since = datetime.now(timezone.utc) - timedelta(days=since_days)
+        records = log_store.tail(category, limit=max(limit, 1), since=since)
+        payload = [record.to_json() for record in records]
+        log_store.prune(config.log_retention_days)
+        return {"category": category, "records": payload}
+
+    @app.get("/api/logs/categories")
+    async def get_log_categories() -> dict[str, Any]:
+        categories = set(log_store.categories()) | {"system", "episodes"}
+        return {"categories": sorted(categories)}
 
     return app
 
@@ -120,7 +265,7 @@ def _render_index(payload: ConfigPayload) -> str:
       color: var(--fg);
     }
     .container {
-      max-width: 960px;
+      max-width: 1000px;
       margin: 0 auto;
       padding: 2rem 1.5rem 4rem;
     }
@@ -150,7 +295,7 @@ def _render_index(payload: ConfigPayload) -> str:
       margin-bottom: 1rem;
       gap: 0.4rem;
     }
-    input, textarea {
+    input, textarea, select {
       padding: 0.6rem 0.8rem;
       border-radius: 8px;
       border: 1px solid var(--border);
@@ -176,10 +321,38 @@ def _render_index(payload: ConfigPayload) -> str:
       opacity: 0.6;
       cursor: progress;
     }
-    #status {
-      margin-top: 1rem;
+    .status-line {
+      margin-top: 0.75rem;
       min-height: 1.25rem;
       font-weight: 600;
+    }
+    .manual-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      gap: 1rem;
+      align-items: end;
+    }
+    .manual-grid label {
+      margin-bottom: 0.5rem;
+    }
+    .log-controls {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 1rem;
+      align-items: flex-end;
+    }
+    .log-controls label {
+      flex: 1 1 160px;
+    }
+    .logs {
+      background: var(--input-bg);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      padding: 1rem;
+      max-height: 320px;
+      overflow: auto;
+      white-space: pre-wrap;
+      word-break: break-word;
     }
     @media (prefers-color-scheme: dark) {
       :root {
@@ -209,7 +382,7 @@ def _render_index(payload: ConfigPayload) -> str:
   <div class=\"container\">
     <header>
       <h1>Graphiti Admin</h1>
-      <p>Configure data sources, polling intervals, and summarisation defaults in one place.</p>
+      <p>Configure data sources, scheduling, and backfills in one place.</p>
     </header>
     <form id=\"config-form\" autocomplete=\"off\">
       <section>
@@ -229,6 +402,13 @@ def _render_index(payload: ConfigPayload) -> str:
         <label>Calendar IDs<input type=\"text\" name=\"calendar_ids\" placeholder=\"primary, team@domain.com\" value=\"$calendars\" /></label>
       </section>
       <section>
+        <h2>Historical Import Defaults</h2>
+        <label>Gmail Backfill (days)<input type=\"number\" min=\"1\" name=\"gmail_backfill_days\" value=\"$gmail_backfill_days\" required /></label>
+        <label>Drive Backfill (days)<input type=\"number\" min=\"1\" name=\"drive_backfill_days\" value=\"$drive_backfill_days\" required /></label>
+        <label>Calendar Backfill (days)<input type=\"number\" min=\"1\" name=\"calendar_backfill_days\" value=\"$calendar_backfill_days\" required /></label>
+        <label>Slack Backfill (days)<input type=\"number\" min=\"1\" name=\"slack_backfill_days\" value=\"$slack_backfill_days\" required /></label>
+      </section>
+      <section>
         <h2>Summarisation & Redaction</h2>
         <label>Strategy<input type=\"text\" name=\"summarization_strategy\" value=\"$summarization_strategy\" required /></label>
         <label>Threshold (characters)<input type=\"number\" min=\"1\" name=\"summarization_threshold\" value=\"$summarization_threshold\" required /></label>
@@ -237,15 +417,67 @@ def _render_index(payload: ConfigPayload) -> str:
         <label>Redaction Rules Path<input type=\"text\" name=\"redaction_rules_path\" value=\"$redaction_rules_path\" /></label>
         <label>Inline Redaction Rules<textarea name=\"redaction_rules\" placeholder=\"sensitive@example.com =&gt; [REDACTED]\">$redaction_lines</textarea></label>
       </section>
+      <section>
+        <h2>Backups & Logging</h2>
+        <label>Backup Directory<input type=\"text\" name=\"backup_directory\" required value=\"$backup_directory\" /></label>
+        <label>Backup Retention (days)<input type=\"number\" min=\"0\" name=\"backup_retention_days\" value=\"$backup_retention_days\" required /></label>
+        <label>Log Retention (days)<input type=\"number\" min=\"0\" name=\"log_retention_days\" value=\"$log_retention_days\" required /></label>
+        <label>Logs Directory<input type=\"text\" name=\"logs_directory\" value=\"$logs_directory\" placeholder=\"Defaults to state directory\" /></label>
+        <button type=\"button\" id=\"run-backup\">Run backup now</button>
+        <div id=\"backup-status\" class=\"status-line\" role=\"status\"></div>
+      </section>
       <div>
         <button type=\"submit\">Save configuration</button>
-        <div id=\"status\" role=\"status\"></div>
+        <div id=\"status\" class=\"status-line\" role=\"status\"></div>
       </div>
     </form>
+
+    <section>
+      <h2>Manual Historical Load</h2>
+      <p>Trigger on-demand backfills when onboarding or reseeding data.</p>
+      <div class=\"manual-grid\">
+        <div>
+          <label>Gmail (days)<input type=\"number\" min=\"1\" name=\"gmail_manual_days\" value=\"$gmail_backfill_days\" data-default=\"$gmail_backfill_days\" /></label>
+          <button type=\"button\" data-service=\"gmail\">Run Gmail Backfill</button>
+        </div>
+        <div>
+          <label>Drive (days)<input type=\"number\" min=\"1\" name=\"drive_manual_days\" value=\"$drive_backfill_days\" data-default=\"$drive_backfill_days\" /></label>
+          <button type=\"button\" data-service=\"drive\">Run Drive Backfill</button>
+        </div>
+        <div>
+          <label>Calendar (days)<input type=\"number\" min=\"1\" name=\"calendar_manual_days\" value=\"$calendar_backfill_days\" data-default=\"$calendar_backfill_days\" /></label>
+          <button type=\"button\" data-service=\"calendar\">Run Calendar Backfill</button>
+        </div>
+        <div>
+          <label>Slack (days)<input type=\"number\" min=\"1\" name=\"slack_manual_days\" value=\"$slack_backfill_days\" data-default=\"$slack_backfill_days\" /></label>
+          <button type=\"button\" data-service=\"slack\">Run Slack Backfill</button>
+        </div>
+      </div>
+      <div id=\"loader-status\" class=\"status-line\" role=\"status\"></div>
+    </section>
+
+    <section>
+      <h2>Logs</h2>
+      <div class=\"log-controls\">
+        <label>Category<select id=\"log-category\"></select></label>
+        <label>Limit<input type=\"number\" id=\"log-limit\" value=\"200\" min=\"1\" /></label>
+        <label>Since (days)<input type=\"number\" id=\"log-since\" min=\"0\" placeholder=\"30\" /></label>
+        <button type=\"button\" id=\"refresh-logs\">Refresh</button>
+      </div>
+      <div id=\"logs-status\" class=\"status-line\" role=\"status\"></div>
+      <pre id=\"logs-output\" class=\"logs\" aria-live=\"polite\"></pre>
+    </section>
   </div>
   <script>
     const form = document.getElementById('config-form');
     const statusEl = document.getElementById('status');
+    const backupStatus = document.getElementById('backup-status');
+    const loaderStatus = document.getElementById('loader-status');
+    const logsStatus = document.getElementById('logs-status');
+    const logsOutput = document.getElementById('logs-output');
+    const logCategorySelect = document.getElementById('log-category');
+    const logLimitInput = document.getElementById('log-limit');
+    const logSinceInput = document.getElementById('log-since');
 
     const parseList = (value) => value.split(',').map((item) => item.trim()).filter(Boolean);
 
@@ -259,15 +491,27 @@ def _render_index(payload: ConfigPayload) -> str:
       }).filter(Boolean);
     };
 
+    const setStatus = (element, message, isError = false) => {
+      if (!element) return;
+      element.textContent = message || '';
+      element.style.color = isError ? '#ef4444' : 'var(--accent)';
+    };
+
     const submit = async (event) => {
       event.preventDefault();
-      statusEl.textContent = '';
+      setStatus(statusEl, '');
       const data = new FormData(form);
       const payload = Object.fromEntries(data.entries());
       payload.poll_gmail_drive_calendar_seconds = Number(payload.poll_gmail_drive_calendar_seconds);
       payload.poll_slack_active_seconds = Number(payload.poll_slack_active_seconds);
       payload.poll_slack_idle_seconds = Number(payload.poll_slack_idle_seconds);
       payload.gmail_fallback_days = Number(payload.gmail_fallback_days);
+      payload.gmail_backfill_days = Number(payload.gmail_backfill_days);
+      payload.drive_backfill_days = Number(payload.drive_backfill_days);
+      payload.calendar_backfill_days = Number(payload.calendar_backfill_days);
+      payload.slack_backfill_days = Number(payload.slack_backfill_days);
+      payload.backup_retention_days = Number(payload.backup_retention_days);
+      payload.log_retention_days = Number(payload.log_retention_days);
       payload.summarization_threshold = Number(payload.summarization_threshold);
       payload.summarization_max_chars = Number(payload.summarization_max_chars);
       payload.summarization_sentence_count = Number(payload.summarization_sentence_count);
@@ -286,17 +530,132 @@ def _render_index(payload: ConfigPayload) -> str:
           const detail = await response.json().catch(() => ({}));
           throw new Error(detail.detail || 'Unable to save configuration');
         }
-        statusEl.textContent = 'Configuration saved successfully.';
-        statusEl.style.color = 'var(--accent)';
+        setStatus(statusEl, 'Configuration saved successfully.');
+        await loadLogCategories().catch(() => {});
       } catch (error) {
-        statusEl.textContent = error.message;
-        statusEl.style.color = '#ef4444';
+        setStatus(statusEl, error.message, true);
       } finally {
         form.querySelector('button[type=\"submit\"]').disabled = false;
       }
     };
 
     form.addEventListener('submit', submit);
+
+    const runBackup = async () => {
+      const button = document.getElementById('run-backup');
+      if (!button) return;
+      setStatus(backupStatus, 'Creating backup...');
+      button.disabled = true;
+      try {
+        const response = await fetch('/api/backup/run', { method: 'POST' });
+        if (!response.ok) {
+          throw new Error('Unable to trigger backup');
+        }
+        const data = await response.json();
+        const message = data.status || 'Backup completed.';
+        setStatus(backupStatus, message);
+        if (data.archive) {
+          await refreshLogs();
+        }
+      } catch (error) {
+        setStatus(backupStatus, error.message, true);
+      } finally {
+        button.disabled = false;
+      }
+    };
+
+    document.getElementById('run-backup').addEventListener('click', runBackup);
+
+    const runManualLoad = async (service, button) => {
+      const input = document.querySelector(`[name="${service}_manual_days"]`);
+      const fallback = Number(input?.dataset.default || '30');
+      const parsed = Number(input?.value || fallback);
+      if (!Number.isFinite(parsed) || parsed < 1) {
+        setStatus(loaderStatus, 'Please provide a valid number of days.', true);
+        return;
+      }
+      const days = Math.floor(parsed);
+      setStatus(loaderStatus, `Running ${service} backfill...`);
+      button.disabled = true;
+      try {
+        const response = await fetch(`/api/manual-load/${service}`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ days }),
+        });
+        if (!response.ok) {
+          const detail = await response.json().catch(() => ({}));
+          throw new Error(detail.detail || 'Backfill failed');
+        }
+        const data = await response.json();
+        setStatus(loaderStatus, `${service} backfill completed: ${data.processed} episodes.`);
+        await refreshLogs();
+      } catch (error) {
+        setStatus(loaderStatus, error.message, true);
+      } finally {
+        button.disabled = false;
+      }
+    };
+
+    document.querySelectorAll('[data-service]').forEach((button) => {
+      button.addEventListener('click', () => runManualLoad(button.dataset.service, button));
+    });
+
+    const loadLogCategories = async () => {
+      try {
+        const response = await fetch('/api/logs/categories');
+        if (!response.ok) {
+          throw new Error('Unable to load log categories');
+        }
+        const data = await response.json();
+        const categories = data.categories || ['system', 'episodes'];
+        logCategorySelect.innerHTML = '';
+        categories.forEach((category) => {
+          const option = document.createElement('option');
+          option.value = category;
+          option.textContent = category;
+          logCategorySelect.appendChild(option);
+        });
+      } catch (error) {
+        logCategorySelect.innerHTML = '<option value="system">system</option>';
+        throw error;
+      }
+    };
+
+    const refreshLogs = async () => {
+      setStatus(logsStatus, 'Loading logs...');
+      try {
+        const params = new URLSearchParams();
+        const category = logCategorySelect.value || 'system';
+        params.set('category', category);
+        const limit = Number(logLimitInput.value || '200');
+        params.set('limit', String(Math.max(1, Math.floor(limit))));
+        const since = Number(logSinceInput.value || '0');
+        if (Number.isFinite(since) && since > 0) {
+          params.set('since_days', String(Math.floor(since)));
+        }
+        const response = await fetch(`/api/logs?${params.toString()}`);
+        if (!response.ok) {
+          throw new Error('Unable to fetch logs');
+        }
+        const data = await response.json();
+        const entries = data.records || [];
+        logsOutput.textContent = entries.length
+          ? entries.map((record) => JSON.stringify(record)).join('\n')
+          : 'No log entries available.';
+        setStatus(logsStatus, `Loaded ${entries.length} log entries.`);
+      } catch (error) {
+        logsOutput.textContent = '';
+        setStatus(logsStatus, error.message, true);
+      }
+    };
+
+    document.getElementById('refresh-logs').addEventListener('click', refreshLogs);
+    logCategorySelect.addEventListener('change', refreshLogs);
+
+    loadLogCategories()
+      .then(refreshLogs)
+      .catch((error) => setStatus(logsStatus, error.message, true));
   </script>
 </body>
 </html>""")
@@ -309,6 +668,10 @@ def _render_index(payload: ConfigPayload) -> str:
         poll_slack_active_seconds=payload.poll_slack_active_seconds,
         poll_slack_idle_seconds=payload.poll_slack_idle_seconds,
         gmail_fallback_days=payload.gmail_fallback_days,
+        gmail_backfill_days=payload.gmail_backfill_days,
+        drive_backfill_days=payload.drive_backfill_days,
+        calendar_backfill_days=payload.calendar_backfill_days,
+        slack_backfill_days=payload.slack_backfill_days,
         allowlist=escape(allowlist),
         calendars=escape(calendars),
         summarization_strategy=escape(payload.summarization_strategy),
@@ -317,7 +680,17 @@ def _render_index(payload: ConfigPayload) -> str:
         summarization_sentence_count=payload.summarization_sentence_count,
         redaction_rules_path=escape(payload.redaction_rules_path or ""),
         redaction_lines=escape(redaction_lines),
+        backup_directory=escape(payload.backup_directory),
+        backup_retention_days=payload.backup_retention_days,
+        log_retention_days=payload.log_retention_days,
+        logs_directory=escape(payload.logs_directory or ""),
     )
+
+
+def _logs_directory(config: GraphitiConfig, state_store: GraphitiStateStore) -> Path:
+    if config.logs_directory:
+        return Path(config.logs_directory).expanduser()
+    return state_store.base_dir / "logs"
 
 
 __all__ = ["create_app"]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -24,8 +24,16 @@ def test_cli_status_outputs_json(monkeypatch, tmp_path, capsys):
                 poll_slack_active_seconds=30,
                 poll_slack_idle_seconds=3600,
                 gmail_fallback_days=7,
+                gmail_backfill_days=365,
+                drive_backfill_days=365,
+                calendar_backfill_days=365,
+                slack_backfill_days=365,
                 calendar_ids=("primary",),
                 slack_channel_allowlist=(),
+                backup_directory="/tmp/backups",
+                backup_retention_days=14,
+                log_retention_days=30,
+                logs_directory=None,
             )
         ),
     )

--- a/tests/test_logs.py
+++ b/tests/test_logs.py
@@ -1,0 +1,36 @@
+from pathlib import Path
+
+from graphiti.logs import GraphitiLogStore
+
+
+def test_log_store_append_and_tail(tmp_path):
+    store = GraphitiLogStore(tmp_path)
+    record = store.append(
+        "system",
+        "hello world",
+        data={"foo": "bar"},
+        retention_days=7,
+    )
+    assert record.message == "hello world"
+    assert record.level == "INFO"
+
+    # additional entry to validate ordering
+    store.append("system", "second", retention_days=7)
+
+    records = store.tail("system", limit=1)
+    assert len(records) == 1
+    assert records[0].message == "second"
+
+    # pruning with zero days clears the file
+    store.prune(0)
+    assert store.tail("system") == []
+    assert Path(tmp_path / "system.log").exists() is False
+
+
+def test_log_store_categories(tmp_path):
+    store = GraphitiLogStore(tmp_path)
+    store.append("system", "entry", retention_days=7)
+    store.append("episodes", "episode", retention_days=7)
+
+    categories = store.categories()
+    assert set(categories) == {"episodes", "system"}

--- a/tests/test_maintenance.py
+++ b/tests/test_maintenance.py
@@ -1,0 +1,19 @@
+from datetime import datetime, timezone
+
+from graphiti.maintenance import next_backup_run
+
+
+def test_next_backup_run_same_day_before_window():
+    # On 2024-01-01 the backup should run at 07:00 UTC (02:00 EST)
+    now = datetime(2024, 1, 1, 6, 0, tzinfo=timezone.utc)
+    scheduled = next_backup_run(now)
+    assert scheduled.date() == now.date()
+    assert scheduled.hour == 7
+    assert scheduled.minute == 0
+
+
+def test_next_backup_run_rollover():
+    now = datetime(2024, 1, 1, 8, 0, tzinfo=timezone.utc)
+    scheduled = next_backup_run(now)
+    assert scheduled > now
+    assert scheduled.date() == datetime(2024, 1, 2, 0, tzinfo=timezone.utc).date()


### PR DESCRIPTION
## Summary
- add configurable historical backfill defaults, backup directory, and log retention settings to the configuration model and admin UI
- implement service-specific backfill routines with jitter-aware rate limiting plus a manual loader API in the web admin
- introduce a daily 02:00 EST backup scheduler, structured log store, and browser log viewer alongside updated documentation

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dc8145aa6c8330b80c5fd1dab5ab54