### PR TITLE
Update Slack search pipeline and rebrand admin UI

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,12 @@
 services:
-  graphiti:
+  personal-assistant:
     image: python:3.12-slim
     working_dir: /app
     command: >-
       bash -lc "python -m pip install --upgrade pip && pip install -r requirements.txt && uvicorn graphiti.web_admin.app:create_app --factory --host 0.0.0.0 --port 8000"
     volumes:
       - ./:/app
-      - graphiti_state:/root/.graphiti_sync
+      - personal_assistant_state:/root/.graphiti_sync
       - pip_cache:/root/.cache/pip
     ports:
       - "8000:8000"
@@ -28,5 +28,5 @@ services:
       - ./neo4j/logs:/logs
       - ./neo4j/import:/var/lib/neo4j/import
 volumes:
-  graphiti_state:
+  personal_assistant_state:
   pip_cache:

--- a/docs/acceptance.md
+++ b/docs/acceptance.md
@@ -1,4 +1,4 @@
-# Graphiti Acceptance Harness
+# Personal Assistant Acceptance Harness
 
 The acceptance harness automates the 14-day ingestion scenario described in the PRD. It feeds synthetic data through every poller, flushes the MCP logger, and verifies that the resulting episodes cover all required sources.
 

--- a/docs/ops.md
+++ b/docs/ops.md
@@ -1,10 +1,10 @@
-# Graphiti Operations Guide
+# Personal Assistant Operations Guide
 
-This document outlines day-to-day operational tasks for running Graphiti in a local environment, including observability, data hygiene, and backup/restore workflows.
+This document outlines day-to-day operational tasks for running Personal Assistant (powered by Graphiti) in a local environment, including observability, data hygiene, and backup/restore workflows.
 
 ## 1. Health Monitoring
 
-- Run `graphiti sync status` to view a textual dashboard summarising the last successful run for Gmail, Drive, Calendar, Slack, and MCP.
+- Run `python -m graphiti.cli sync status` to view a textual dashboard summarising the last successful run for Gmail, Drive, Calendar, Slack, and MCP.
 - Append `--json` to emit the raw payload for scripting integrations.
 - Start the lightweight health service by embedding `graphiti.health.create_health_app()` into a WSGI/FastAPI runner. The `/health` endpoint returns a JSON document with last run timestamps, error counters, and overall status (`ok`, `stale`, or `error`).
 - Investigate any source marked as `stale` (no run within two polling intervals) or `error` (non-zero error count).
@@ -20,12 +20,12 @@ This document outlines day-to-day operational tasks for running Graphiti in a lo
 
 ## 3. Backup & Restore
 
-Graphiti stores OAuth tokens and poller checkpoints under `~/.graphiti_sync/`. Regular backups protect against accidental deletion or workstation migrations.
+Personal Assistant stores OAuth tokens and poller checkpoints under `~/.graphiti_sync/`. Regular backups protect against accidental deletion or workstation migrations.
 
 ### 3.1 Creating Backups
 
 ```bash
-graphiti backup state --output ~/Backups
+python -m graphiti.cli backup state --output ~/Backups
 ```
 
 - If `--output` is omitted, the archive is created in the current working directory.
@@ -35,12 +35,12 @@ graphiti backup state --output ~/Backups
 ### 3.2 Restoring from Backups
 
 ```bash
-graphiti restore state /path/to/graphiti-state-20240101120000.tar.gz
+python -m graphiti.cli restore state /path/to/graphiti-state-20240101120000.tar.gz
 ```
 
 - Existing state contents are replaced with the archive contents after safety validation (no path traversal).
 - File permissions are reset to `0700` for directories and `0600` for files to preserve local-only access.
-- After restoring, rerun the relevant `graphiti sync ... --once` command to resume polling from the restored checkpoints.
+- After restoring, rerun the relevant `python -m graphiti.cli sync ... --once` command to resume polling from the restored checkpoints.
 
 ### 3.3 Retention Recommendations
 
@@ -49,9 +49,9 @@ graphiti restore state /path/to/graphiti-state-20240101120000.tar.gz
 
 ## 4. Incident Runbook
 
-- **Health endpoint reports `stale`:** run the associated `graphiti sync <source> --once` command. If it fails, inspect `~/.graphiti_sync/state.json` for corrupted cursors and restore from the latest backup.
+- **Health endpoint reports `stale`:** run the associated `python -m graphiti.cli sync <source> --once` command. If it fails, inspect `~/.graphiti_sync/state.json` for corrupted cursors and restore from the latest backup.
 - **Authentication failures:** delete only the provider-specific token entry in `tokens.json`, rerun the poller, and complete OAuth re-authentication when prompted.
 - **Disk usage growth:** review the size of `graphiti-state-*.tar.gz` archives and prune old backups beyond the retention window.
 
-Maintaining these operational habits ensures Graphiti remains resilient, auditable, and recoverable even when offline for extended periods.
+Maintaining these operational habits ensures Personal Assistant remains resilient, auditable, and recoverable even when offline for extended periods.
 

--- a/docs/task_plan.md
+++ b/docs/task_plan.md
@@ -1,4 +1,4 @@
-# Graphiti Implementation Task Plan
+# Personal Assistant Implementation Task Plan
 
 This plan decomposes the Graphiti PRD into tightly scoped engineering tasks that can be executed and tracked independently. Tasks are grouped by milestone and sequenced to minimize cross-component blocking. Each task includes a goal, key steps, completion criteria, and dependencies.
 
@@ -64,13 +64,13 @@ This plan decomposes the Graphiti PRD into tightly scoped engineering tasks that
 
 ## Milestone M1 — Slack Poller
 
-### 7. Slack Client & Channel Enumeration
-- **Goal:** Build Slack API wrapper for listing accessible channels/DMs per PRD Section 4.1.
+### 7. Slack Client & Search Support
+- **Goal:** Build Slack API wrapper for executing search queries per PRD Section 4.1.
 - **Steps:**
   1. Implement token-based authentication and rate-limit aware HTTP client.
-  2. Provide functions to list channels, DMs, MPIMs respecting optional allowlist config.
-  3. Persist discovered channel metadata in local state for reuse.
-- **Completion Criteria:** Tests simulate API responses and confirm allowlist filter. CLI `sync slack --list-channels` prints channel IDs.
+  2. Provide helpers for `search.messages` with pagination, timestamp filtering, and graceful handling of truncated results.
+  3. Persist discovered channel and user metadata in local state for reuse and caching.
+- **Completion Criteria:** Tests simulate search responses and confirm metadata caching. CLI `sync slack --list-channels` prints channel IDs.
 - **Dependencies:** Task 1.
 
 ### 8. Slack Message Poller with Thread Support

--- a/graphiti/config.py
+++ b/graphiti/config.py
@@ -60,7 +60,7 @@ class GraphitiConfig:
     drive_backfill_days: int = 365
     calendar_backfill_days: int = 365
     slack_backfill_days: int = 365
-    slack_channel_allowlist: tuple[str, ...] = ()
+    slack_search_query: str = ""
     calendar_ids: tuple[str, ...] = ("primary",)
     redaction_rules_path: str | None = None
     redaction_rules: tuple[tuple[str, str], ...] = ()
@@ -126,8 +126,11 @@ class GraphitiConfig:
             slack_backfill_days=get_int(
                 "SLACK_BACKFILL_DAYS", defaults.slack_backfill_days
             ),
-            slack_channel_allowlist=_parse_csv(
-                values.get("SLACK_CHANNEL_ALLOWLIST"), defaults.slack_channel_allowlist
+            slack_search_query=(
+                _clean_optional_str(
+                    values.get("SLACK_SEARCH_QUERY"), defaults.slack_search_query
+                )
+                or ""
             ),
             calendar_ids=_parse_csv(
                 values.get("CALENDAR_IDS"), defaults.calendar_ids
@@ -256,9 +259,9 @@ class GraphitiConfig:
             slack_backfill_days=get_int(
                 "slack_backfill_days", defaults.slack_backfill_days
             ),
-            slack_channel_allowlist=get_seq(
-                "slack_channel_allowlist", defaults.slack_channel_allowlist
-            ),
+            slack_search_query=get_str(
+                "slack_search_query", defaults.slack_search_query
+            ).strip(),
             calendar_ids=get_seq("calendar_ids", defaults.calendar_ids),
             redaction_rules_path=values.get(
                 "redaction_rules_path", defaults.redaction_rules_path
@@ -294,7 +297,7 @@ class GraphitiConfig:
 
     def to_json(self) -> Dict[str, Any]:
         payload = asdict(self)
-        payload["slack_channel_allowlist"] = list(self.slack_channel_allowlist)
+        payload["slack_search_query"] = self.slack_search_query
         payload["calendar_ids"] = list(self.calendar_ids)
         payload["redaction_rules"] = [
             {"pattern": pattern, "replacement": replacement}
@@ -461,7 +464,7 @@ ENV_KEYS = {
     "DRIVE_BACKFILL_DAYS",
     "CALENDAR_BACKFILL_DAYS",
     "SLACK_BACKFILL_DAYS",
-    "SLACK_CHANNEL_ALLOWLIST",
+    "SLACK_SEARCH_QUERY",
     "CALENDAR_IDS",
     "REDACTION_RULES_PATH",
     "REDACTION_RULES",

--- a/graphiti/health.py
+++ b/graphiti/health.py
@@ -75,7 +75,7 @@ def format_dashboard(metrics: Mapping[str, Any]) -> str:
     """Render a textual dashboard summarising sync health."""
 
     generated = metrics.get("generated_at")
-    header = "Graphiti Sync Status"
+    header = "Personal Assistant Sync Status"
     if isinstance(generated, str):
         header += f" — {generated}"
     lines = [header, ""]

--- a/graphiti/web_admin/__init__.py
+++ b/graphiti/web_admin/__init__.py
@@ -1,4 +1,4 @@
-"""Admin web application for configuring Graphiti."""
+"""Admin web application for configuring Personal Assistant."""
 
 from .app import create_app
 

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
-# Graphiti Personal & Enterprise Assistant
+# Personal Assistant (Graphiti-powered)
 
-Graphiti is a local-first knowledge graph that continuously ingests Gmail, Google Drive, Google Calendar, Slack, and MCP/Cursor activity so your assistant can answer time-aware questions. This repository contains the product requirements, task plan, and a full Python reference implementation with pollers, persistence helpers, health checks, and an acceptance harness.
+Personal Assistant is a Graphiti-powered, local-first knowledge graph that continuously ingests Gmail, Google Drive, Google Calendar, Slack, and MCP/Cursor activity so your assistant can answer time-aware questions. This repository contains the product requirements, task plan, and a full Python reference implementation with pollers, persistence helpers, health checks, and an acceptance harness.
 
 The guide below walks a new operator through the entire setup — from installing prerequisites and creating API credentials to running the pollers, verifying health, and backing up state.
 
@@ -8,9 +8,9 @@ The guide below walks a new operator through the entire setup — from installin
 
 1. Install Docker Desktop or another Docker runtime.
 2. Clone the repository and start the bundled admin UI via Docker (no local Python needed).
-3. Configure Graphiti through the web admin at <http://localhost:8000>.
+3. Configure Personal Assistant through the web admin at <http://localhost:8000>.
 4. Create OAuth credentials for Google Workspace APIs and generate a user token for Slack.
-5. Store the tokens under `~/.graphiti_sync/` and confirm Graphiti can read them.
+5. Store the tokens under `~/.graphiti_sync/` and confirm Personal Assistant can read them.
 6. Use the admin UI's manual loaders to backfill ~365 days of history for Gmail, Drive, Calendar, and Slack.
 7. Run the Gmail, Drive, Calendar, and Slack pollers once to confirm incremental sync.
 8. Let the built-in 02:00 EST backup job archive state (or trigger a manual backup from the UI) and monitor logs directly in the browser.
@@ -31,13 +31,13 @@ Each step is detailed below.
 ### 1. Clone the repository
 
 ```bash
-git clone https://github.com/graphiti-dev/personal-assistant.git
+git clone https://github.com/otreva/personal-assistant.git
 cd personal-assistant
 ```
 
 ### 2. Launch the Dockerised admin UI
 
-Graphiti ships with a `docker-compose.yml` file that now boots both the admin UI and a
+Personal Assistant ships with a `docker-compose.yml` file that now boots both the admin UI and a
 Neo4j 5 instance. The compose stack mounts your repository, caches Python dependencies,
 and persists Neo4j data to `./neo4j/` so you can tear the stack down without losing the
 database. No local Python environment is required.
@@ -64,7 +64,7 @@ database. No local Python environment is required.
 Both approaches expose the admin UI on <http://localhost:8000>. The first compose run
 builds the Python environment; subsequent runs reuse the cached volume for faster starts.
 
-### 3. Configure Graphiti from the web admin
+### 3. Configure Personal Assistant from the web admin
 
 Visit <http://localhost:8000> after starting the container. The admin UI detects existing
 settings from `~/.graphiti_sync/config.json` (created on first launch) and provides a dark
@@ -81,7 +81,7 @@ secure permissions.
 
 ### 4. Review the state directory
 
-Graphiti stores OAuth tokens, poller checkpoints, and configuration under
+Personal Assistant stores OAuth tokens, poller checkpoints, and configuration under
 `~/.graphiti_sync/`. The admin UI surfaces the active paths in the **Backups & Logging**
 tab and automatically manages file permissions—no manual commands required.
 
@@ -110,9 +110,10 @@ tab and automatically manages file permissions—no manual commands required.
 
 ### 7. Verify configuration and inventory Slack channels
 
-Use the **Inventory Slack Channels** button in the Slack Workspace card to fetch all
-available channels and persist their metadata to state. The results appear inline and
-respect the allowlist configured in the **Polling Behaviour** section.
+Use the **Inventory Slack Channels** button in the Slack Workspace card to refresh the cached
+channel metadata. The results appear inline and complement the Slack search query configured
+in the **Polling Behaviour** section, which determines which messages Personal Assistant
+ingests.
 
 ### 8. Backfill the last year of history
 
@@ -121,7 +122,7 @@ Calendar, and Slack backfills. The defaults load 365 days of activity and includ
 rate-limit friendly pauses with jitter. You can rerun the loader at any time to fetch
 additional history without affecting incremental checkpoints.
 
-### 9. Run the pollers to seed Graphiti
+### 9. Run the pollers to seed Personal Assistant
 
 Use the **Run Pollers Once** section in the admin UI to trigger Gmail, Drive, Calendar,
 and Slack pollers on demand. The UI displays the number of episodes processed and records
@@ -145,7 +146,7 @@ Integrate your MCP or Cursor workflow by creating `McpTurn` objects and logging 
 
 ### 12. Back up and restore state
 
-Graphiti automatically creates a timestamped `.tar.gz` backup of `~/.graphiti_sync/`
+Personal Assistant automatically creates a timestamped `.tar.gz` backup of `~/.graphiti_sync/`
 every day at **02:00 EST**. Archives are written to the directory configured in the
 admin UI (default `~/.graphiti_sync/backups`) and older files are pruned according to the
 retention window. Use the **Run Backup** button in the Backups card to trigger an ad-hoc

--- a/scripts/docker-run.sh
+++ b/scripts/docker-run.sh
@@ -3,8 +3,8 @@ set -euo pipefail
 
 IMAGE="python:3.12-slim"
 APP_DIR="/app"
-STATE_VOLUME="graphiti_state"
-CACHE_VOLUME="graphiti_pip_cache"
+STATE_VOLUME="personal_assistant_state"
+CACHE_VOLUME="personal_assistant_pip_cache"
 PORT="8000"
 
 if ! command -v docker >/dev/null 2>&1; then

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -29,7 +29,7 @@ def test_cli_status_outputs_json(monkeypatch, tmp_path, capsys):
                 calendar_backfill_days=365,
                 slack_backfill_days=365,
                 calendar_ids=("primary",),
-                slack_channel_allowlist=(),
+                slack_search_query="in:general",
                 backup_directory="/tmp/backups",
                 backup_retention_days=14,
                 log_retention_days=30,
@@ -104,7 +104,7 @@ def test_cli_sync_status(monkeypatch, tmp_path, capsys):
     exit_code = cli.main(["sync", "status"])
     assert exit_code == 0
     output = capsys.readouterr().out
-    assert "Graphiti Sync Status" in output
+    assert "Personal Assistant Sync Status" in output
     assert "gmail" in output
     assert "123" not in output  # checkpoint details suppressed in dashboard
 
@@ -150,9 +150,7 @@ def test_cli_sync_scheduler_once(monkeypatch, tmp_path, capsys):
     slack_poller.run_once.return_value = 2
     monkeypatch.setattr(cli, "create_slack_client", lambda config, state: mock.Mock())
 
-    monkeypatch.setattr(
-        cli, "SlackPoller", lambda client, store, state, allowlist: slack_poller
-    )
+    monkeypatch.setattr(cli, "SlackPoller", lambda client, store, state: slack_poller)
 
     exit_code = cli.main(["sync", "scheduler", "--once"])
     assert exit_code == 0

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -45,7 +45,7 @@ def test_invalid_numeric_input_raises(
 def test_config_store_round_trip(config_path: Path) -> None:
     store = ConfigStore(config_path)
     original = GraphitiConfig(
-        slack_channel_allowlist=("C1", "C2"),
+        slack_search_query="in:general",
         calendar_ids=("primary", "team"),
         summarization_threshold=2000,
         redaction_rules=(
@@ -56,7 +56,7 @@ def test_config_store_round_trip(config_path: Path) -> None:
     store.save(original)
 
     loaded = store.load()
-    assert loaded.slack_channel_allowlist == ("C1", "C2")
+    assert loaded.slack_search_query == "in:general"
     assert loaded.calendar_ids == ("primary", "team")
     assert loaded.summarization_threshold == 2000
     assert loaded.redaction_rules == (

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -52,7 +52,7 @@ def test_format_dashboard_outputs_table(tmp_path):
     config = GraphitiConfig(group_id="g")
     metrics = collect_health_metrics(store, config)
     output = format_dashboard(metrics)
-    assert "Graphiti Sync Status" in output
+    assert "Personal Assistant Sync Status" in output
     assert "slack" in output
 
 


### PR DESCRIPTION
## Summary
- rename the documentation and admin interface to Personal Assistant and update repository references
- replace the Slack channel allowlist with a configurable `slack_search_query`, caching user/channel metadata and reworking the poller to use `search.messages`
- add operating system directory pickers for backup and log settings plus expose the new Slack search field in the admin UI

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dc8ca74854833082992b0b568bddd3